### PR TITLE
Support tvOS

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,1 +1,1 @@
-pod 'KeenClientTD', '= 3.2.24'
+pod 'KeenClientTD', '= 3.2.25'

--- a/TreasureData-iOS-SDK.podspec
+++ b/TreasureData-iOS-SDK.podspec
@@ -11,6 +11,6 @@ Pod::Spec.new do |s|
   s.library      = 'z'
   s.frameworks   = ['Security']
   s.public_header_files = ["TreasureData/TreasureData.h", "TreasureData/TDClient.h"]
-  s.dependency "KeenClientTD", '= 3.2.24'
+  s.dependency "KeenClientTD", '= 3.2.25'
   s.requires_arc = true
 end

--- a/TreasureData-iOS-SDK.podspec
+++ b/TreasureData-iOS-SDK.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   s.summary      = "TreasureData SDK for iOS."
   s.license      = "Apache"
   s.author       = { "TreasureData" => "mitsu@treasure-data.com" }
-  s.platform     = :ios
+  s.platform     = { :ios => "", :tvos => "" }
   s.homepage     = "https://github.com/treasure-data/td-ios-sdk"
   s.source       = { :git => "https://github.com/treasure-data/td-ios-sdk.git", :tag => "0.1.14" }
   s.source_files  = 'TreasureData'

--- a/TreasureData/TreasureData.m
+++ b/TreasureData/TreasureData.m
@@ -29,7 +29,11 @@ static NSString *keyOfOsType = @"td_os_type";
 static NSString *keyOfSessionId = @"td_session_id";
 static NSString *keyOfSessionEvent = @"td_session_event";
 static NSString *keyOfServerSideUploadTimestamp = @"#SSUT";
+#if TARGET_OS_TV
+static NSString *osType = @"tvOS";
+#else
 static NSString *osType = @"iOS";
+#endif
 static NSString *sessionEventStart = @"start";
 static NSString *sessionEventEnd = @"end";
 

--- a/TreasureData/TreasureData.m
+++ b/TreasureData/TreasureData.m
@@ -42,8 +42,6 @@ static NSString *sessionEventEnd = @"end";
 
 @implementation TreasureData
 - (id)initWithApiKey:(NSString *)apiKey {
-    [KeenClient disableGeoLocation];
-
     self = [self init];
 
     if (self) {


### PR DESCRIPTION
Removed the use of deprecated method from [KeenClientTD (3.2.25)](https://github.com/treasure-data/KeenClient-iOS/tree/td_3.2.25), which supports tvOS in the latest version. The platform specification is also added to the podspec.