### PR TITLE
Attach App Locale Info

### DIFF
--- a/TreasureData/TreasureData.h
+++ b/TreasureData/TreasureData.h
@@ -55,6 +55,10 @@
 
 - (void)enableAutoAppendModelInformation;
 
+- (void)disableAutoAppendAppInformation;
+
+- (void)enableAutoAppendAppInformation;
+
 - (void)disableRetryUploading;
 
 - (void)enableRetryUploading;

--- a/TreasureData/TreasureData.h
+++ b/TreasureData/TreasureData.h
@@ -59,6 +59,10 @@
 
 - (void)enableAutoAppendAppInformation;
 
+- (void)disableAutoAppendLocaleInformation;
+
+- (void)enableAutoAppendLocaleInformation;
+
 - (void)disableRetryUploading;
 
 - (void)enableRetryUploading;

--- a/TreasureData/TreasureData.m
+++ b/TreasureData/TreasureData.m
@@ -26,6 +26,8 @@ static NSString *keyOfDisplay = @"td_display";
 static NSString *keyOfModel = @"td_model";
 static NSString *keyOfOsVer = @"td_os_ver";
 static NSString *keyOfOsType = @"td_os_type";
+static NSString *keyOfAppVer = @"td_app_ver";
+static NSString *keyOfAppVerNum = @"td_app_ver_num";
 static NSString *keyOfSessionId = @"td_session_id";
 static NSString *keyOfSessionEvent = @"td_session_event";
 static NSString *keyOfServerSideUploadTimestamp = @"#SSUT";
@@ -36,6 +38,7 @@ static NSString *sessionEventEnd = @"end";
 @interface TreasureData ()
 @property BOOL autoAppendUniqId;
 @property BOOL autoAppendModelInformation;
+@property BOOL autoAppendAppInformation;
 @property NSString *sessionId;
 @property BOOL serverSideUploadTimestamp;
 @end
@@ -108,6 +111,9 @@ static NSString *sessionEventEnd = @"end";
                 if (self.autoAppendModelInformation) {
                     record = [self appendModelInformation:record];
                 }
+                if (self.autoAppendAppInformation) {
+                    record = [self appendAppInformation:record];
+                }
                 if (self.sessionId) {
                     record = [self appendSessionId:record];
                 }
@@ -173,6 +179,14 @@ static NSString *sessionEventEnd = @"end";
     return record;
 }
 
+- (NSDictionary *)appendAppInformation:(NSDictionary *)origRecord {
+    NSMutableDictionary *record = [NSMutableDictionary dictionaryWithDictionary:origRecord];
+    NSBundle *bundle = [NSBundle mainBundle];
+    record[keyOfAppVer] = [bundle objectForInfoDictionaryKey:@"CFBundleShortVersionString"] ?: @"";
+    record[keyOfAppVerNum] = [bundle objectForInfoDictionaryKey:(NSString *)kCFBundleVersionKey] ?: @"";
+    return [record copy];
+}
+
 - (NSDictionary*)appendSessionId:(NSDictionary *)origRecord {
     NSMutableDictionary *record = [NSMutableDictionary dictionaryWithDictionary:origRecord];
     [record setValue:self.sessionId forKey:keyOfSessionId];
@@ -235,6 +249,14 @@ static NSString *sessionEventEnd = @"end";
 
 - (void)enableAutoAppendModelInformation {
     self.autoAppendModelInformation = true;
+}
+
+- (void)disableAutoAppendAppInformation {
+    self.autoAppendAppInformation = false;
+}
+
+- (void)enableAutoAppendAppInformation {
+    self.autoAppendAppInformation = true;
 }
 
 - (void)disableRetryUploading {

--- a/TreasureData/TreasureData.m
+++ b/TreasureData/TreasureData.m
@@ -28,6 +28,8 @@ static NSString *keyOfOsVer = @"td_os_ver";
 static NSString *keyOfOsType = @"td_os_type";
 static NSString *keyOfAppVer = @"td_app_ver";
 static NSString *keyOfAppVerNum = @"td_app_ver_num";
+static NSString *keyOfLocaleCountry = @"td_locale_country";
+static NSString *keyOfLocaleLang = @"td_locale_lang";
 static NSString *keyOfSessionId = @"td_session_id";
 static NSString *keyOfSessionEvent = @"td_session_event";
 static NSString *keyOfServerSideUploadTimestamp = @"#SSUT";
@@ -39,6 +41,7 @@ static NSString *sessionEventEnd = @"end";
 @property BOOL autoAppendUniqId;
 @property BOOL autoAppendModelInformation;
 @property BOOL autoAppendAppInformation;
+@property BOOL autoAppendLocaleInformation;
 @property NSString *sessionId;
 @property BOOL serverSideUploadTimestamp;
 @end
@@ -114,6 +117,9 @@ static NSString *sessionEventEnd = @"end";
                 if (self.autoAppendAppInformation) {
                     record = [self appendAppInformation:record];
                 }
+                if (self.autoAppendLocaleInformation) {
+                    record = [self appendLocaleInformation:record];
+                }
                 if (self.sessionId) {
                     record = [self appendSessionId:record];
                 }
@@ -187,6 +193,13 @@ static NSString *sessionEventEnd = @"end";
     return [record copy];
 }
 
+- (NSDictionary *)appendLocaleInformation:(NSDictionary *)origRecord {
+    NSMutableDictionary *record = [NSMutableDictionary dictionaryWithDictionary:origRecord];
+    record[keyOfLocaleCountry] = [[NSLocale currentLocale] objectForKey:NSLocaleCountryCode] ?: @"";
+    record[keyOfLocaleLang] = [[NSLocale preferredLanguages] firstObject] ?: @"";
+    return [record copy];
+}
+
 - (NSDictionary*)appendSessionId:(NSDictionary *)origRecord {
     NSMutableDictionary *record = [NSMutableDictionary dictionaryWithDictionary:origRecord];
     [record setValue:self.sessionId forKey:keyOfSessionId];
@@ -257,6 +270,14 @@ static NSString *sessionEventEnd = @"end";
 
 - (void)enableAutoAppendAppInformation {
     self.autoAppendAppInformation = true;
+}
+
+- (void)disableAutoAppendLocaleInformation {
+    self.autoAppendLocaleInformation = false;
+}
+
+- (void)enableAutoAppendLocaleInformation {
+    self.autoAppendLocaleInformation = true;
 }
 
 - (void)disableRetryUploading {

--- a/TreasureDataTests/TreasureDataTests.m
+++ b/TreasureDataTests/TreasureDataTests.m
@@ -307,6 +307,38 @@ static NSString *END_POINT = @"http://localhost";
             }];
 }
 
+- (void)testAutoAppendAppInformation {
+  [self baseTesting:^{
+    [self.td enableAutoAppendAppInformation];
+    [self setupDefaultExpectedResponseBody:@{@"db_.tbl": @[@{@"success":@"true"}]}];
+    [self.td addEvent:@{@"name":@"foobar"} database:@"db_" table:@"tbl"];
+  }
+          assertion:^(NSDictionary *ev) {
+            XCTAssertEqual(1, self.session.sendRequestCount);
+            XCTAssertEqual(1, ev.count);
+            NSArray *arr = [ev objectForKey:@"db_.tbl"];
+            [self assertCollectedValueWithKey:arr key:@"name" expectedVals:@[@"foobar"]
+                                 expectedKeys:@[@"name", @"keen", @"#UUID", @"td_app_ver", @"td_app_ver_num"]
+             ];
+          }];
+}
+
+- (void)testAutoAppendLocaleInformation {
+  [self baseTesting:^{
+    [self.td enableAutoAppendLocaleInformation];
+    [self setupDefaultExpectedResponseBody:@{@"db_.tbl": @[@{@"success":@"true"}]}];
+    [self.td addEvent:@{@"name":@"foobar"} database:@"db_" table:@"tbl"];
+  }
+          assertion:^(NSDictionary *ev) {
+            XCTAssertEqual(1, self.session.sendRequestCount);
+            XCTAssertEqual(1, ev.count);
+            NSArray *arr = [ev objectForKey:@"db_.tbl"];
+            [self assertCollectedValueWithKey:arr key:@"name" expectedVals:@[@"foobar"]
+                                 expectedKeys:@[@"name", @"keen", @"#UUID", @"td_locale_country", @"td_locale_lang"]
+             ];
+          }];
+}
+
 - (void)testIsFirstRun {
     XCTAssertTrue([self.td isFirstRun]);
     [self.td clearFirstRun];


### PR DESCRIPTION
Toggle the following info attached to each event automatically, using the same keys that [td-android-sdk](https://github.com/treasure-data/td-android-sdk#adding-application-package-version-information-to-each-event-automatically) uses:

#### enableAutoAppendAppInformation

- [x] `td_app_ver` : [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"]
- [x] `td_app_ver_num` : [[NSBundle mainBundle] objectForInfoDictionaryKey:kCFBundleVersionKey]

#### enableAutoAppendLocaleInformation

- [x] `td_locale_country` : [[NSLocale currentLocale] objectForKey:NSLocaleCountryCode]
- [x] `td_locale_lang` : [[NSLocale preferredLanguages] firstObject]

Please see if these are compatible with the current configurations, thanks!