### PR TITLE
Avoid specifying an endpoint verbosely in demo app

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ You can detect if it's the first running or not easily using `isFirstRun` method
 The API endpoint (default: https://in.treasuredata.com) can be modified using `initializeApiEndpoint` class method. For example,
 
 ```
-    [TreasureData initializeApiEndpoint:@"https://in.treasuredata.com"];
+    [TreasureData initializeApiEndpoint:@"https://specifying-another-endpoint.com"];
     [TreasureData initializeWithApiKey:@"your_api_key"];
 ```
 

--- a/TreasureDataExample/TreasureDataExample/TreasureDataExample.m
+++ b/TreasureDataExample/TreasureDataExample/TreasureDataExample.m
@@ -17,7 +17,7 @@ static NSString *testTable;
 
 + (void)setupTreasureData {
     [TreasureData enableLogging];
-    [TreasureData initializeApiEndpoint:@"https://in.treasuredata.com"];
+    // [TreasureData initializeApiEndpoint:@"https://specify-other-endpoint-if-needed.com"];
     [TreasureData initializeEncryptionKey:@"encryption_key"];
     [TreasureData initializeWithApiKey:@"api_key"];
     [[TreasureData sharedInstance] setDefaultDatabase:@"your_db"];


### PR DESCRIPTION
Original code specified an endpoint that's same as default endpoint. Developers don't need to specify it in their app.