### PR TITLE
Integration tests along with multiple iOS versions coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,7 @@ jobs:
 
       - store_artifacts:
           path: ./logs
+          destination: logs
 
       - store_test_results:
           path: ./test_results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,4 +25,5 @@ jobs:
                     -destination 'platform=iOS Simulator,name=iPhone 7,OS=12.1' \
                     -destination 'platform=iOS Simulator,name=iPhone 7,OS=11.2' \
                     -destination 'platform=iOS Simulator,name=iPhone 7,OS=10.3.1' \
+                    TD_DEV_MASTER_KEY=$(TD_DEV_MASTER_KEY)
                     test | xcpretty && exit ${PIPESTATUS[0]}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,24 +6,47 @@ jobs:
       xcode: "10.1.0"
 
     steps:
+
       - checkout
 
-      - run:
-          name: Install CocoaPods
-          command: pod install
+      - restore_cache:
+          name: Restore Pods cache
+          keys:
+            - v2-pods-{{ checksum "Podfile.lock" }}
 
-      - run: gem install xcpretty --user-install
+      - run:
+          name: Install Pods
+          command: ./scripts/ci_pod_install
+
+      - save_cache:
+          name: Saving Pods cache
+          key: v2-pods-{{ checksum "Podfile.lock" }}
+          paths:
+            - Pods
+            - ~/.cocoapods
 
       - run:
-          name: Tests
-          command: >
-            xcodebuild \
-                    -workspace TreasureData.xcworkspace \
-                    -scheme TreasureData \
-                    -sdk iphonesimulator \
-                    -disable-concurrent-destination-testing \
-                    -destination 'platform=iOS Simulator,name=iPhone 7,OS=12.1' \
-                    -destination 'platform=iOS Simulator,name=iPhone 7,OS=11.2' \
-                    -destination 'platform=iOS Simulator,name=iPhone 7,OS=10.3.1' \
-                    TD_DEV_MASTER_KEY=$(TD_DEV_MASTER_KEY)
-                    test | xcpretty && exit ${PIPESTATUS[0]}
+          name: Install additional tools
+          command: |
+            gem install xcpretty --user-install
+
+      - run:
+          name: Tests on iOS 12
+          command: ./scripts/ci_test 'platform=iOS Simulator,name=iPhone 7,OS=12.1' logs_xcbuild_ios_12.txt
+      - store_artifacts:
+          path: logs_xcbuild_ios_12.txt
+          destination: logs_xcbuild_ios_12.txt
+
+      - run:
+          name: Tests on iOS 11
+          command: ./scripts/ci_test 'platform=iOS Simulator,name=iPhone 7,OS=11.2' logs_xcbuild_ios_11.txt
+      - store_artifacts:
+          path: logs_xcbuild_ios_11.txt
+          destination: logs_xcbuild_ios_11.txt
+
+      - run:
+          name: Tests on iOS 10
+          command: ./scripts/ci_test 'platform=iOS Simulator,name=iPhone 7,OS=10.3.1' logs_xcbuild_ios_10.txt
+      - store_artifacts:
+          path: logs_xcbuild_ios_10.txt
+          destination: logs_xcbuild_ios_10.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,27 +26,26 @@ jobs:
             - ~/.cocoapods
 
       - run:
-          name: Install additional tools
+          name: Auxiliary setup
           command: |
             gem install xcpretty --user-install
+            HOMEBREW_NO_AUTO_UPDATE=1 brew install gnu-sed
+            mkdir logs test_results
 
       - run:
           name: Tests on iOS 12
-          command: ./scripts/ci_test 'platform=iOS Simulator,name=iPhone 7,OS=12.1' logs_xcbuild_ios_12.txt
-      - store_artifacts:
-          path: logs_xcbuild_ios_12.txt
-          destination: logs_xcbuild_ios_12.txt
+          command: ./scripts/ci_test 'platform=iOS Simulator,name=iPhone 7,OS=12.1' logs/xcbuild_ios_12.log test_results/ios_12.xml
 
       - run:
           name: Tests on iOS 11
-          command: ./scripts/ci_test 'platform=iOS Simulator,name=iPhone 7,OS=11.2' logs_xcbuild_ios_11.txt
-      - store_artifacts:
-          path: logs_xcbuild_ios_11.txt
-          destination: logs_xcbuild_ios_11.txt
+          command: ./scripts/ci_test 'platform=iOS Simulator,name=iPhone 7,OS=11.2' logs/xcbuild_ios_11.log test_results/ios_11.xml
 
       - run:
           name: Tests on iOS 10
-          command: ./scripts/ci_test 'platform=iOS Simulator,name=iPhone 7,OS=10.3.1' logs_xcbuild_ios_10.txt
+          command: ./scripts/ci_test 'platform=iOS Simulator,name=iPhone 7,OS=10.3.1' logs/xcbuild_ios_10.log test_results/ios_10.xml
+
       - store_artifacts:
-          path: logs_xcbuild_ios_10.txt
-          destination: logs_xcbuild_ios_10.txt
+          path: ./logs
+
+      - store_test_results:
+          path: ./test_results

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .DS_Store
-Podfile.lock
 Pods/
 *.xcworkspace
 xcuserdata

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,0 +1,18 @@
+PODS:
+  - KeenClientTD (3.2.34):
+    - KeenClientTD/keen_sqlite (= 3.2.34)
+  - KeenClientTD/keen_sqlite (3.2.34)
+
+DEPENDENCIES:
+  - KeenClientTD (= 3.2.34)
+
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - KeenClientTD
+
+SPEC CHECKSUMS:
+  KeenClientTD: 62b6bfcc42c32e0fa623fafb24739fcfc2edf586
+
+PODFILE CHECKSUM: 096a72cf9020a39499b673eb80fff9f5d2664183
+
+COCOAPODS: 1.5.3

--- a/TestHost/AppDelegate.swift
+++ b/TestHost/AppDelegate.swift
@@ -1,0 +1,46 @@
+//
+//  AppDelegate.swift
+//  TestHost
+//
+//  Created by Huy TD on 1/28/19.
+//  Copyright © 2019 Huy TD. All rights reserved.
+//
+
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    var window: UIWindow?
+
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    func applicationWillResignActive(_ application: UIApplication) {
+        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+        // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.
+    }
+
+    func applicationDidEnterBackground(_ application: UIApplication) {
+        // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
+        // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+    }
+
+    func applicationWillEnterForeground(_ application: UIApplication) {
+        // Called as part of the transition from the background to the active state; here you can undo many of the changes made on entering the background.
+    }
+
+    func applicationDidBecomeActive(_ application: UIApplication) {
+        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+    }
+
+    func applicationWillTerminate(_ application: UIApplication) {
+        // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+    }
+
+
+}
+

--- a/TestHost/AppDelegate.swift
+++ b/TestHost/AppDelegate.swift
@@ -2,8 +2,8 @@
 //  AppDelegate.swift
 //  TestHost
 //
-//  Created by Huy TD on 1/28/19.
-//  Copyright © 2019 Huy TD. All rights reserved.
+//  Created by huylenq on 1/28/19.
+//  Copyright © 2019 Arm Treasure Data. All rights reserved.
 //
 
 import UIKit

--- a/TestHost/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/TestHost/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/TestHost/Assets.xcassets/Contents.json
+++ b/TestHost/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/TestHost/Base.lproj/LaunchScreen.storyboard
+++ b/TestHost/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/TestHost/Base.lproj/Main.storyboard
+++ b/TestHost/Base.lproj/Main.storyboard
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/TestHost/Info.plist
+++ b/TestHost/Info.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/TestHost/ViewController.swift
+++ b/TestHost/ViewController.swift
@@ -2,8 +2,8 @@
 //  ViewController.swift
 //  TestHost
 //
-//  Created by Huy TD on 1/28/19.
-//  Copyright © 2019 Huy TD. All rights reserved.
+//  Created by huylenq on 1/28/19.
+//  Copyright © 2019 Arm TreasureData. All rights reserved.
 //
 
 import UIKit

--- a/TestHost/ViewController.swift
+++ b/TestHost/ViewController.swift
@@ -1,0 +1,20 @@
+//
+//  ViewController.swift
+//  TestHost
+//
+//  Created by Huy TD on 1/28/19.
+//  Copyright © 2019 Huy TD. All rights reserved.
+//
+
+import UIKit
+
+class ViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Do any additional setup after loading the view, typically from a nib.
+    }
+
+
+}
+

--- a/TreasureData.xcodeproj/project.pbxproj
+++ b/TreasureData.xcodeproj/project.pbxproj
@@ -26,6 +26,13 @@
 		6BF8C92F1A3E972C005B1804 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6BF8C92E1A3E972C005B1804 /* Security.framework */; };
 		6BF8C9311A3E977B005B1804 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 6BF8C9301A3E977B005B1804 /* libz.dylib */; };
 		6BF8C9341A3E9B76005B1804 /* TDClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BF8C9331A3E9B76005B1804 /* TDClient.m */; };
+		E52CB7F521FDD78A00062EBA /* TDAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = E52CB7F421FDD78A00062EBA /* TDAPI.swift */; };
+		E5A84B5421FEA35300BC699D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5A84B5321FEA35300BC699D /* AppDelegate.swift */; };
+		E5A84B5621FEA35300BC699D /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5A84B5521FEA35300BC699D /* ViewController.swift */; };
+		E5A84B5921FEA35300BC699D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E5A84B5721FEA35300BC699D /* Main.storyboard */; };
+		E5A84B5B21FEA35700BC699D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E5A84B5A21FEA35700BC699D /* Assets.xcassets */; };
+		E5A84B5E21FEA35700BC699D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E5A84B5C21FEA35700BC699D /* LaunchScreen.storyboard */; };
+		E5AD3AF22219A4E8001392BA /* IntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5AD3AF12219A4E8001392BA /* IntegrationTests.swift */; };
 		EF5A04E746876D639D752AE1 /* libPods-TreasureData.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 11FADA7F69E6E148978C0F7C /* libPods-TreasureData.a */; };
 /* End PBXBuildFile section */
 
@@ -36,6 +43,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 6B73808D192A09160097D56E;
 			remoteInfo = TreasureData;
+		};
+		E5A84B6321FEA36000BC699D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 6B738086192A09160097D56E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E5A84B5021FEA35300BC699D;
+			remoteInfo = TestHost;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -90,6 +104,16 @@
 		C672A66407ACBC0B49C815A4 /* Pods-TreasureDataTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TreasureDataTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TreasureDataTests/Pods-TreasureDataTests.debug.xcconfig"; sourceTree = "<group>"; };
 		D4602B9A0FADB71F2C158763 /* Pods-Common-TreasureDataTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Common-TreasureDataTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Common-TreasureDataTests/Pods-Common-TreasureDataTests.release.xcconfig"; sourceTree = "<group>"; };
 		E0DB92B1F49BBC30A854EB53 /* libPods-TreasureDataTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-TreasureDataTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E52CB7F121FDD6D300062EBA /* TreasureDataTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "TreasureDataTests-Bridging-Header.h"; sourceTree = "<group>"; };
+		E52CB7F421FDD78A00062EBA /* TDAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TDAPI.swift; sourceTree = "<group>"; };
+		E5A84B5121FEA35300BC699D /* TestHost.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TestHost.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		E5A84B5321FEA35300BC699D /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		E5A84B5521FEA35300BC699D /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		E5A84B5821FEA35300BC699D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		E5A84B5A21FEA35700BC699D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		E5A84B5D21FEA35700BC699D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		E5A84B5F21FEA35700BC699D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E5AD3AF12219A4E8001392BA /* IntegrationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IntegrationTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -117,6 +141,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		E5A84B4E21FEA35300BC699D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -125,9 +156,9 @@
 			children = (
 				6B738093192A09160097D56E /* TreasureData */,
 				6B7380A7192A09160097D56E /* TreasureDataTests */,
+				E5A84B5221FEA35300BC699D /* TestHost */,
 				6B738090192A09160097D56E /* Frameworks */,
 				6B73808F192A09160097D56E /* Products */,
-				81303D87A0647FB407EA911A /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -136,6 +167,7 @@
 			children = (
 				6B73808E192A09160097D56E /* libTreasureData.a */,
 				6B73809E192A09160097D56E /* TreasureDataTests.xctest */,
+				E5A84B5121FEA35300BC699D /* TestHost.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -143,6 +175,7 @@
 		6B738090192A09160097D56E /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				81303D87A0647FB407EA911A /* Pods */,
 				6BF8C9301A3E977B005B1804 /* libz.dylib */,
 				6BF8C92E1A3E972C005B1804 /* Security.framework */,
 				6BF8C92C1A3E971D005B1804 /* CoreLocation.framework */,
@@ -188,6 +221,9 @@
 				6B7380AD192A09160097D56E /* TreasureDataTests.m */,
 				6B7380A8192A09160097D56E /* Supporting Files */,
 				6BB5A9D51D1BBFE60006A534 /* SessionTests.m */,
+				E5AD3AF12219A4E8001392BA /* IntegrationTests.swift */,
+				E52CB7F121FDD6D300062EBA /* TreasureDataTests-Bridging-Header.h */,
+				E52CB7F421FDD78A00062EBA /* TDAPI.swift */,
 			);
 			path = TreasureDataTests;
 			sourceTree = "<group>";
@@ -216,6 +252,19 @@
 				D4602B9A0FADB71F2C158763 /* Pods-Common-TreasureDataTests.release.xcconfig */,
 			);
 			name = Pods;
+			sourceTree = "<group>";
+		};
+		E5A84B5221FEA35300BC699D /* TestHost */ = {
+			isa = PBXGroup;
+			children = (
+				E5A84B5321FEA35300BC699D /* AppDelegate.swift */,
+				E5A84B5721FEA35300BC699D /* Main.storyboard */,
+				E5A84B5A21FEA35700BC699D /* Assets.xcassets */,
+				E5A84B5521FEA35300BC699D /* ViewController.swift */,
+				E5A84B5C21FEA35700BC699D /* LaunchScreen.storyboard */,
+				E5A84B5F21FEA35700BC699D /* Info.plist */,
+			);
+			path = TestHost;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -255,11 +304,29 @@
 			);
 			dependencies = (
 				6B7380A5192A09160097D56E /* PBXTargetDependency */,
+				E5A84B6421FEA36000BC699D /* PBXTargetDependency */,
 			);
 			name = TreasureDataTests;
 			productName = TreasureDataTests;
 			productReference = 6B73809E192A09160097D56E /* TreasureDataTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		E5A84B5021FEA35300BC699D /* TestHost */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E5A84B6021FEA35700BC699D /* Build configuration list for PBXNativeTarget "TestHost" */;
+			buildPhases = (
+				E5A84B4D21FEA35300BC699D /* Sources */,
+				E5A84B4E21FEA35300BC699D /* Frameworks */,
+				E5A84B4F21FEA35300BC699D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = TestHost;
+			productName = TestHost;
+			productReference = E5A84B5121FEA35300BC699D /* TestHost.app */;
+			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
 
@@ -267,8 +334,20 @@
 		6B738086192A09160097D56E /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftUpdateCheck = 1010;
 				LastUpgradeCheck = 0920;
 				ORGANIZATIONNAME = "___FULLUSERNAME___";
+				TargetAttributes = {
+					6B73809D192A09160097D56E = {
+						LastSwiftMigration = 1010;
+						TestTargetID = E5A84B5021FEA35300BC699D;
+					};
+					E5A84B5021FEA35300BC699D = {
+						CreatedOnToolsVersion = 10.1;
+						DevelopmentTeam = U5YLXH98R7;
+						ProvisioningStyle = Automatic;
+					};
+				};
 			};
 			buildConfigurationList = 6B738089192A09160097D56E /* Build configuration list for PBXProject "TreasureData" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -276,6 +355,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 6B738085192A09160097D56E;
 			productRefGroup = 6B73808F192A09160097D56E /* Products */;
@@ -284,6 +364,7 @@
 			targets = (
 				6B73808D192A09160097D56E /* TreasureData */,
 				6B73809D192A09160097D56E /* TreasureDataTests */,
+				E5A84B5021FEA35300BC699D /* TestHost */,
 			);
 		};
 /* End PBXProject section */
@@ -294,6 +375,16 @@
 			buildActionMask = 2147483647;
 			files = (
 				6B7380AC192A09160097D56E /* InfoPlist.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E5A84B4F21FEA35300BC699D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E5A84B5E21FEA35700BC699D /* LaunchScreen.storyboard in Resources */,
+				E5A84B5B21FEA35700BC699D /* Assets.xcassets in Resources */,
+				E5A84B5921FEA35300BC699D /* Main.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -401,7 +492,18 @@
 			buildActionMask = 2147483647;
 			files = (
 				6BB5A9D61D1BBFE60006A534 /* SessionTests.m in Sources */,
+				E5AD3AF22219A4E8001392BA /* IntegrationTests.swift in Sources */,
 				6B7380AE192A09160097D56E /* TreasureDataTests.m in Sources */,
+				E52CB7F521FDD78A00062EBA /* TDAPI.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E5A84B4D21FEA35300BC699D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E5A84B5621FEA35300BC699D /* ViewController.swift in Sources */,
+				E5A84B5421FEA35300BC699D /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -413,6 +515,11 @@
 			target = 6B73808D192A09160097D56E /* TreasureData */;
 			targetProxy = 6B7380A4192A09160097D56E /* PBXContainerItemProxy */;
 		};
+		E5A84B6421FEA36000BC699D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E5A84B5021FEA35300BC699D /* TestHost */;
+			targetProxy = E5A84B6321FEA36000BC699D /* PBXContainerItemProxy */;
+		};
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
@@ -422,6 +529,22 @@
 				6B7380AB192A09160097D56E /* en */,
 			);
 			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
+		E5A84B5721FEA35300BC699D /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				E5A84B5821FEA35300BC699D /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		E5A84B5C21FEA35700BC699D /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				E5A84B5D21FEA35700BC699D /* Base */,
+			);
+			name = LaunchScreen.storyboard;
 			sourceTree = "<group>";
 		};
 /* End PBXVariantGroup section */
@@ -561,6 +684,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = C672A66407ACBC0B49C815A4 /* Pods-TreasureDataTests.debug.xcconfig */;
 			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_MODULES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
@@ -574,8 +699,13 @@
 				);
 				INFOPLIST_FILE = "TreasureDataTests/TreasureDataTests-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "TreasureDataTests/TreasureDataTests-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.2;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TestHost.app/TestHost";
 				WRAPPER_EXTENSION = xctest;
 			};
 			name = Debug;
@@ -584,6 +714,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 644A82FEB7ABBA6EEE825324 /* Pods-TreasureDataTests.release.xcconfig */;
 			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_MODULES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
@@ -593,9 +725,76 @@
 				GCC_PREFIX_HEADER = "TreasureData/TreasureData-Prefix.pch";
 				INFOPLIST_FILE = "TreasureDataTests/TreasureDataTests-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "TreasureDataTests/TreasureDataTests-Bridging-Header.h";
+				SWIFT_VERSION = 4.2;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TestHost.app/TestHost";
 				WRAPPER_EXTENSION = xctest;
+			};
+			name = Release;
+		};
+		E5A84B6121FEA35700BC699D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = U5YLXH98R7;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = TestHost/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.treasuredata.TestHost;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.2;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		E5A84B6221FEA35700BC699D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = U5YLXH98R7;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = TestHost/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.treasuredata.TestHost;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 4.2;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};
@@ -625,6 +824,15 @@
 			buildConfigurations = (
 				6B7380B5192A09160097D56E /* Debug */,
 				6B7380B6192A09160097D56E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E5A84B6021FEA35700BC699D /* Build configuration list for PBXNativeTarget "TestHost" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E5A84B6121FEA35700BC699D /* Debug */,
+				E5A84B6221FEA35700BC699D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/TreasureData.xcodeproj/project.pbxproj
+++ b/TreasureData.xcodeproj/project.pbxproj
@@ -69,11 +69,14 @@
 
 /* Begin PBXFileReference section */
 		11FADA7F69E6E148978C0F7C /* libPods-TreasureData.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-TreasureData.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		19CFD6BDE2E7D4AC4F0869FF /* Pods-TreasureDataTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TreasureDataTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-TreasureDataTests/Pods-TreasureDataTests.release.xcconfig"; sourceTree = "<group>"; };
 		201053E9204858F8009C7EFA /* Constants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Constants.h; sourceTree = "<group>"; };
 		2053A39B2047F37F0089A959 /* TDUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TDUtils.m; sourceTree = "<group>"; };
 		2053A39D2047F38B0089A959 /* TDUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TDUtils.h; sourceTree = "<group>"; };
 		27C46146494E527DCE7A92A1 /* Pods-TreasureData-TreasureDataTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TreasureData-TreasureDataTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TreasureData-TreasureDataTests/Pods-TreasureData-TreasureDataTests.debug.xcconfig"; sourceTree = "<group>"; };
 		361BA221499EFE17CB2E88D1 /* Pods-Common-TreasureDataTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Common-TreasureDataTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Common-TreasureDataTests/Pods-Common-TreasureDataTests.debug.xcconfig"; sourceTree = "<group>"; };
+		3B4F21DEB3BEAC61738A3481 /* Pods-TreasureData.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TreasureData.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TreasureData/Pods-TreasureData.debug.xcconfig"; sourceTree = "<group>"; };
+		42CA51289C7213A40BD4A2E5 /* Pods-TreasureDataTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TreasureDataTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TreasureDataTests/Pods-TreasureDataTests.debug.xcconfig"; sourceTree = "<group>"; };
 		4D4265C575E11B5930549F10 /* Pods-Common-TreasureData.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Common-TreasureData.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Common-TreasureData/Pods-Common-TreasureData.debug.xcconfig"; sourceTree = "<group>"; };
 		57CFB8AE9EF047FBDE70DEA8 /* Pods-Common-TreasureData.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Common-TreasureData.release.xcconfig"; path = "Pods/Target Support Files/Pods-Common-TreasureData/Pods-Common-TreasureData.release.xcconfig"; sourceTree = "<group>"; };
 		644A82FEB7ABBA6EEE825324 /* Pods-TreasureDataTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TreasureDataTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-TreasureDataTests/Pods-TreasureDataTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -103,6 +106,7 @@
 		9F0EF4E7CEE8DA4E298326B9 /* Pods-TreasureData.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TreasureData.release.xcconfig"; path = "Pods/Target Support Files/Pods-TreasureData/Pods-TreasureData.release.xcconfig"; sourceTree = "<group>"; };
 		C672A66407ACBC0B49C815A4 /* Pods-TreasureDataTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TreasureDataTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TreasureDataTests/Pods-TreasureDataTests.debug.xcconfig"; sourceTree = "<group>"; };
 		D4602B9A0FADB71F2C158763 /* Pods-Common-TreasureDataTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Common-TreasureDataTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Common-TreasureDataTests/Pods-Common-TreasureDataTests.release.xcconfig"; sourceTree = "<group>"; };
+		DC74A9280B244A4C25A4F155 /* Pods-TreasureData.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TreasureData.release.xcconfig"; path = "Pods/Target Support Files/Pods-TreasureData/Pods-TreasureData.release.xcconfig"; sourceTree = "<group>"; };
 		E0DB92B1F49BBC30A854EB53 /* libPods-TreasureDataTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-TreasureDataTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E52CB7F121FDD6D300062EBA /* TreasureDataTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "TreasureDataTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		E52CB7F421FDD78A00062EBA /* TDAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TDAPI.swift; sourceTree = "<group>"; };
@@ -159,6 +163,7 @@
 				E5A84B5221FEA35300BC699D /* TestHost */,
 				6B738090192A09160097D56E /* Frameworks */,
 				6B73808F192A09160097D56E /* Products */,
+				F48413E1384BA388BC58FA8C /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -267,6 +272,17 @@
 			path = TestHost;
 			sourceTree = "<group>";
 		};
+		F48413E1384BA388BC58FA8C /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				3B4F21DEB3BEAC61738A3481 /* Pods-TreasureData.debug.xcconfig */,
+				DC74A9280B244A4C25A4F155 /* Pods-TreasureData.release.xcconfig */,
+				42CA51289C7213A40BD4A2E5 /* Pods-TreasureDataTests.debug.xcconfig */,
+				19CFD6BDE2E7D4AC4F0869FF /* Pods-TreasureDataTests.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -278,7 +294,6 @@
 				6B73808A192A09160097D56E /* Sources */,
 				6B73808B192A09160097D56E /* Frameworks */,
 				6B73808C192A09160097D56E /* CopyFiles */,
-				9EBA1F044C24E6A640CAF055 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -297,8 +312,6 @@
 				6B73809A192A09160097D56E /* Sources */,
 				6B73809B192A09160097D56E /* Frameworks */,
 				6B73809C192A09160097D56E /* Resources */,
-				55A58BE0DFF4BC9C1102BCD8 /* [CP] Embed Pods Frameworks */,
-				2E8AFDBC88EE236B7A1B972E /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -391,36 +404,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		2E8AFDBC88EE236B7A1B972E /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TreasureDataTests/Pods-TreasureDataTests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		55A58BE0DFF4BC9C1102BCD8 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TreasureDataTests/Pods-TreasureDataTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		5F62EAC907F3EEA5C1BAB630 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -455,21 +438,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		9EBA1F044C24E6A640CAF055 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TreasureData/Pods-TreasureData-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -754,7 +722,7 @@
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = TestHost/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -786,7 +754,7 @@
 				DEVELOPMENT_TEAM = U5YLXH98R7;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = TestHost/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;

--- a/TreasureData.xcodeproj/xcshareddata/xcschemes/TreasureData.xcscheme
+++ b/TreasureData.xcodeproj/xcshareddata/xcschemes/TreasureData.xcscheme
@@ -50,8 +50,13 @@
       </MacroExpansion>
       <EnvironmentVariables>
          <EnvironmentVariable
-            key = "TD_DEV_MASTER_KEY"
-            value = "$(TD_DEV_MASTER_KEY)"
+            key = "API_MASTER_KEY"
+            value = "$(API_MASTER_KEY)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "API_ENDPOINT"
+            value = "$(API_ENDPOINT)"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>

--- a/TreasureData.xcodeproj/xcshareddata/xcschemes/TreasureData.xcscheme
+++ b/TreasureData.xcodeproj/xcshareddata/xcschemes/TreasureData.xcscheme
@@ -26,8 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "NO">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -40,6 +39,22 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6B73809D192A09160097D56E"
+            BuildableName = "TreasureDataTests.xctest"
+            BlueprintName = "TreasureDataTests"
+            ReferencedContainer = "container:TreasureData.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "TD_DEV_MASTER_KEY"
+            value = "$(TD_DEV_MASTER_KEY)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>
@@ -47,7 +62,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
@@ -72,6 +86,15 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6B73808D192A09160097D56E"
+            BuildableName = "libTreasureData.a"
+            BlueprintName = "TreasureData"
+            ReferencedContainer = "container:TreasureData.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/TreasureData.xcodeproj/xcshareddata/xcschemes/TreasureData.xcscheme
+++ b/TreasureData.xcodeproj/xcshareddata/xcschemes/TreasureData.xcscheme
@@ -59,6 +59,11 @@
             value = "$(API_ENDPOINT)"
             isEnabled = "YES">
          </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "COLLECTOR_ENDPOINT"
+            value = "$(COLLECTOR_ENDPOINT)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
       </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>

--- a/TreasureDataExample/Podfile.lock
+++ b/TreasureDataExample/Podfile.lock
@@ -1,0 +1,25 @@
+PODS:
+  - KeenClientTD (3.2.33):
+    - KeenClientTD/keen_sqlite (= 3.2.33)
+  - KeenClientTD/keen_sqlite (3.2.33)
+  - TreasureData-iOS-SDK (0.1.27):
+    - KeenClientTD (= 3.2.33)
+
+DEPENDENCIES:
+  - TreasureData-iOS-SDK (from `..`)
+
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - KeenClientTD
+
+EXTERNAL SOURCES:
+  TreasureData-iOS-SDK:
+    :path: ".."
+
+SPEC CHECKSUMS:
+  KeenClientTD: 1faa85dca8fe1cf14a7b5c1a736a4fa9ea42fea7
+  TreasureData-iOS-SDK: ec344c7340885fa48c2f7ed0b4598a9be0309c97
+
+PODFILE CHECKSUM: 99b35cd9cef5e0ef2908311a9f1b4e428bb2a1fc
+
+COCOAPODS: 1.5.3

--- a/TreasureDataExample/TreasureDataExample/Base.lproj/Main.storyboard
+++ b/TreasureDataExample/TreasureDataExample/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="vgE-gp-ZtG">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="vgE-gp-ZtG">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment version="2304" identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -22,7 +22,7 @@
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <subviews>
                                 <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="TDLogo" translatesAutoresizingMaskIntoConstraints="NO" id="ehx-3c-zWb">
-                                    <rect key="frame" x="163" y="-105" width="50" height="308"/>
+                                    <rect key="frame" x="162.5" y="-105" width="50" height="308"/>
                                     <constraints>
                                         <constraint firstAttribute="width" constant="50" id="D3k-xC-kW8"/>
                                     </constraints>
@@ -341,7 +341,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ya0-Km-wTJ" userLabel="Add Event">
-                                                    <rect key="frame" x="0.0" y="6" width="375" height="30"/>
+                                                    <rect key="frame" x="0.0" y="7" width="375" height="30"/>
                                                     <state key="normal" title="Add Test Event"/>
                                                     <connections>
                                                         <action selector="addEvent:" destination="vgE-gp-ZtG" eventType="touchUpInside" id="sVD-SC-1om"/>
@@ -365,7 +365,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lNj-Qp-PFr">
-                                                    <rect key="frame" x="0.0" y="6" width="375" height="30"/>
+                                                    <rect key="frame" x="0.0" y="7" width="375" height="30"/>
                                                     <state key="normal" title="Upload Events"/>
                                                     <connections>
                                                         <action selector="uploadEvents:" destination="vgE-gp-ZtG" eventType="touchUpInside" id="nwp-Ml-zac"/>
@@ -388,7 +388,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hDv-Ru-qWK">
-                                                    <rect key="frame" x="0.0" y="6" width="375" height="30"/>
+                                                    <rect key="frame" x="0.0" y="7" width="375" height="30"/>
                                                     <state key="normal" title="Reset Device Unique ID"/>
                                                     <connections>
                                                         <action selector="resetDeviceUniqueID:" destination="vgE-gp-ZtG" eventType="touchUpInside" id="FRz-cd-AI0"/>
@@ -426,7 +426,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="CfC-PW-9XH" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-267.5" y="337.5"/>
+            <point key="canvasLocation" x="-428" y="303.59820089955025"/>
         </scene>
     </scenes>
     <resources>

--- a/TreasureDataTests/IntegrationTests.swift
+++ b/TreasureDataTests/IntegrationTests.swift
@@ -1,0 +1,120 @@
+//
+//  TreasureDataSwiftTests.swift
+//  TreasureDataTests
+//
+//  Created by Huy TD on 1/27/19.
+//  Copyright © 2019 Huy TD. All rights reserved.
+//
+
+import XCTest
+
+class IntegrationTests: XCTestCase {
+
+    var sdkClient: TreasureData!
+    static var api: TDAPI!
+    static var apiKey: String!
+
+    static var sessionPrefix = uuid()
+    static var targetDatabase = "ios_integration_tests"
+
+    /** Tables used in a single test */
+    var tempTables: [String] = []
+
+    override class func setUp() {
+        apiKey = ProcessInfo.processInfo.environment["TD_DEV_MASTER_KEY"]
+        api = TDAPI.init(endpoint: "https://api-development.treasuredata.com", apiKey: apiKey)
+        if (!(try! api.isDatabaseExist(targetDatabase))) {
+            fatalError("Either the apiKey is invalid or the target database \(targetDatabase) is not exist!")
+        }
+    }
+
+    override func setUp() {
+        TreasureData.initializeApiEndpoint("https://in-development.treasuredata.com")
+        sdkClient = TreasureData(apiKey: IntegrationTests.apiKey)
+        sdkClient.defaultDatabase = IntegrationTests.targetDatabase
+        tempTables = []
+    }
+
+    override func tearDown() {
+        let remoteTables = Set<String>(IntegrationTests.api.listTables(database: IntegrationTests.targetDatabase))
+        for sessionTable in tempTables {
+            if remoteTables.contains(sessionTable) {
+                try! IntegrationTests.api.deleteTable(database: IntegrationTests.targetDatabase, table: sessionTable)
+            } else {
+                print("WARN: Skip deleting table '\(IntegrationTests.targetDatabase).\(sessionTable)' as it is not exist!")
+            }
+        }
+        sdkClient.disableAppLifecycleEvent()
+        sdkClient = nil
+        IntegrationTests.api = nil
+    }
+
+    func testCustomEvent() {
+        sdkClient.enableCustomEvent()
+        let table = newTempTable()
+        let event = sdkClient.addEvent(["message": "Guten Morgen!"], table: table)
+        sdkClient.uploadEvents()
+        if event != nil {
+            let result = try! IntegrationTests.api.stubbornQuery("select message from \(table) limit 1", database: "huy")
+            XCTAssert(result[0][0] as! String == "Guten Morgen!")
+        } else {
+            XCTFail("Could not create event!")
+        }
+    }
+
+    func testLifeCycleAppOpenedEvent() {
+        sdkClient.enableAppLifecycleEvent()
+        sdkClient.defaultTable = newTempTable()
+        NotificationCenter.default.post(name: Notification.Name("UIApplicationDidFinishLaunchingNotification"), object: nil)
+        sdkClient.uploadEvents()
+        let result = try! IntegrationTests.api.stubbornQuery(
+            "select td_ios_event, td_app_ver, td_app_ver_num from \(sdkClient.defaultTable!) limit 1",
+            database: IntegrationTests.targetDatabase)
+        XCTAssert(result[0][0] as! String == "TD_IOS_APP_OPEN")
+        XCTAssertNotNil(result[0][1])
+        XCTAssertNotNil(result[0][2])
+    }
+
+    func testSession() {
+        let sessionTable = newTempTable()
+        let eventTable = newTempTable()
+
+        sdkClient.startSession(sessionTable)
+        let sessionId: String = sdkClient.getSessionId()!
+
+        sdkClient.addEvent(["event": "in_session_event"], table: eventTable)
+        sdkClient.endSession(sessionTable)
+        sdkClient.addEvent(["event": "not_in_session_event"], table: eventTable)
+        sdkClient.uploadEvents()
+
+        let sessionRecords = try! IntegrationTests.api.stubbornQuery(
+            "select td_session_event, td_session_id from \(sessionTable)",
+            database: IntegrationTests.targetDatabase)
+        let sessionEvents: Set = [sessionRecords[0][0] as! String, sessionRecords[1][0] as! String]
+        XCTAssertTrue(sessionEvents.contains("start"))
+        XCTAssertTrue(sessionEvents.contains("end"))
+        XCTAssertEqual(sessionRecords[0][1] as! String, sessionId)
+        XCTAssertEqual(sessionRecords[1][1] as! String, sessionId)
+
+        let eventRecords = try! IntegrationTests.api.stubbornQuery(
+            "select td_session_id, event from \(eventTable)",
+            database: IntegrationTests.targetDatabase)
+        for event in eventRecords {
+            if (event[1] as! String == "in_session_event") {
+                XCTAssertEqual(event[0] as? String, sessionId)
+            } else if (event[1] as! String == "not_in_session_event") {
+                XCTAssertEqual(event[0] as! String, "")
+            }
+        }
+    }
+
+    private func newTempTable() -> String {
+        let table: String = "ios_integration_test_" + NSUUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "_")
+        tempTables.append(table)
+        return table
+    }
+
+    static func uuid() -> String {
+        return NSUUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "_")
+    }
+}

--- a/TreasureDataTests/IntegrationTests.swift
+++ b/TreasureDataTests/IntegrationTests.swift
@@ -13,6 +13,7 @@ class IntegrationTests: XCTestCase {
     var sdkClient: TreasureData!
     static var api: TDAPI!
     static var apiKey: String!
+    static var collectorEndpoint: String!
 
     static let TargetDatabase = "ios_it"
     static var sessionPrefix = uuid()
@@ -27,8 +28,13 @@ class IntegrationTests: XCTestCase {
         guard let apiEndpoint = ProcessInfo.processInfo.environment["API_ENDPOINT"] else {
             fatalError("Missing env API_ENDPOINT")
         }
+        guard let collectorEndpoint = ProcessInfo.processInfo.environment["COLLECTOR_ENDPOINT"] else {
+            fatalError("Missing env COLLECTOR_ENDPOINT")
+        }
 
         IntegrationTests.apiKey = apiKey
+        IntegrationTests.collectorEndpoint = collectorEndpoint
+
         api = TDAPI.init(endpoint: apiEndpoint, apiKey: apiKey)
         if (!(try! api.isDatabaseExist(TargetDatabase))) {
             fatalError("Either the apiKey is invalid or the target database \(TargetDatabase) is not exist!")
@@ -40,7 +46,7 @@ class IntegrationTests: XCTestCase {
     }
 
     override func setUp() {
-        TreasureData.initializeApiEndpoint("https://in-development.treasuredata.com")
+        TreasureData.initializeApiEndpoint(IntegrationTests.collectorEndpoint)
         sdkClient = TreasureData(apiKey: IntegrationTests.apiKey)
         sdkClient.defaultDatabase = IntegrationTests.TargetDatabase
         tempTables = []

--- a/TreasureDataTests/IntegrationTests.swift
+++ b/TreasureDataTests/IntegrationTests.swift
@@ -86,7 +86,7 @@ class IntegrationTests: XCTestCase {
         let result = try! IntegrationTests.api.stubbornQuery(
             "select td_ios_event, td_app_ver, td_app_ver_num from \(sdkClient.defaultTable!) limit 1",
             database: IntegrationTests.TargetDatabase)
-        XCTAssert(result[0][0] as! String == "TD_IOS_APP_OPEN")
+        XCTAssertEqual(result[0][0] as! String, "TD_IOS_APP_OPEN")
         XCTAssertNotNil(result[0][1])
         XCTAssertNotNil(result[0][2])
     }

--- a/TreasureDataTests/IntegrationTests.swift
+++ b/TreasureDataTests/IntegrationTests.swift
@@ -21,8 +21,10 @@ class IntegrationTests: XCTestCase {
     var tempTables: [String] = []
 
     override class func setUp() {
-        apiKey = ProcessInfo.processInfo.environment["TD_DEV_MASTER_KEY"]
-        api = TDAPI.init(endpoint: "https://api-development.treasuredata.com", apiKey: apiKey)
+        apiKey = ProcessInfo.processInfo.environment["API_MASTER_KEY"]
+        apiEndpoint = ProcessInfo.processInfo.environment["API_ENDPOINT"]
+
+        api = TDAPI.init(endpoint: "API_ENDPOINT", apiKey: apiKey)
         if (!(try! api.isDatabaseExist(TargetDatabase))) {
             fatalError("Either the apiKey is invalid or the target database \(TargetDatabase) is not exist!")
         }

--- a/TreasureDataTests/IntegrationTests.swift
+++ b/TreasureDataTests/IntegrationTests.swift
@@ -14,8 +14,8 @@ class IntegrationTests: XCTestCase {
     static var api: TDAPI!
     static var apiKey: String!
 
+    static let TargetDatabase = "ios_it"
     static var sessionPrefix = uuid()
-    static var targetDatabase = "ios_integration_tests"
 
     /** Tables used in a single test */
     var tempTables: [String] = []
@@ -23,30 +23,33 @@ class IntegrationTests: XCTestCase {
     override class func setUp() {
         apiKey = ProcessInfo.processInfo.environment["TD_DEV_MASTER_KEY"]
         api = TDAPI.init(endpoint: "https://api-development.treasuredata.com", apiKey: apiKey)
-        if (!(try! api.isDatabaseExist(targetDatabase))) {
-            fatalError("Either the apiKey is invalid or the target database \(targetDatabase) is not exist!")
+        if (!(try! api.isDatabaseExist(TargetDatabase))) {
+            fatalError("Either the apiKey is invalid or the target database \(TargetDatabase) is not exist!")
         }
+    }
+
+    override class func tearDown() {
+        IntegrationTests.api = nil
     }
 
     override func setUp() {
         TreasureData.initializeApiEndpoint("https://in-development.treasuredata.com")
         sdkClient = TreasureData(apiKey: IntegrationTests.apiKey)
-        sdkClient.defaultDatabase = IntegrationTests.targetDatabase
+        sdkClient.defaultDatabase = IntegrationTests.TargetDatabase
         tempTables = []
     }
 
     override func tearDown() {
-        let remoteTables = Set<String>(IntegrationTests.api.listTables(database: IntegrationTests.targetDatabase))
+        let remoteTables = Set<String>(IntegrationTests.api.listTables(database: IntegrationTests.TargetDatabase))
         for sessionTable in tempTables {
             if remoteTables.contains(sessionTable) {
-                try! IntegrationTests.api.deleteTable(database: IntegrationTests.targetDatabase, table: sessionTable)
+                try! IntegrationTests.api.deleteTable(database: IntegrationTests.TargetDatabase, table: sessionTable)
             } else {
-                print("WARN: Skip deleting table '\(IntegrationTests.targetDatabase).\(sessionTable)' as it is not exist!")
+                print("WARN: Skip deleting table '\(IntegrationTests.TargetDatabase).\(sessionTable)' as it is not exist!")
             }
         }
         sdkClient.disableAppLifecycleEvent()
         sdkClient = nil
-        IntegrationTests.api = nil
     }
 
     func testCustomEvent() {
@@ -55,7 +58,7 @@ class IntegrationTests: XCTestCase {
         let event = sdkClient.addEvent(["message": "Guten Morgen!"], table: table)
         sdkClient.uploadEvents()
         if event != nil {
-            let result = try! IntegrationTests.api.stubbornQuery("select message from \(table) limit 1", database: "huy")
+            let result = try! IntegrationTests.api.stubbornQuery("select message from \(table) limit 1", database: IntegrationTests.TargetDatabase)
             XCTAssert(result[0][0] as! String == "Guten Morgen!")
         } else {
             XCTFail("Could not create event!")
@@ -69,7 +72,7 @@ class IntegrationTests: XCTestCase {
         sdkClient.uploadEvents()
         let result = try! IntegrationTests.api.stubbornQuery(
             "select td_ios_event, td_app_ver, td_app_ver_num from \(sdkClient.defaultTable!) limit 1",
-            database: IntegrationTests.targetDatabase)
+            database: IntegrationTests.TargetDatabase)
         XCTAssert(result[0][0] as! String == "TD_IOS_APP_OPEN")
         XCTAssertNotNil(result[0][1])
         XCTAssertNotNil(result[0][2])
@@ -89,7 +92,7 @@ class IntegrationTests: XCTestCase {
 
         let sessionRecords = try! IntegrationTests.api.stubbornQuery(
             "select td_session_event, td_session_id from \(sessionTable)",
-            database: IntegrationTests.targetDatabase)
+            database: IntegrationTests.TargetDatabase)
         let sessionEvents: Set = [sessionRecords[0][0] as! String, sessionRecords[1][0] as! String]
         XCTAssertTrue(sessionEvents.contains("start"))
         XCTAssertTrue(sessionEvents.contains("end"))
@@ -98,7 +101,7 @@ class IntegrationTests: XCTestCase {
 
         let eventRecords = try! IntegrationTests.api.stubbornQuery(
             "select td_session_id, event from \(eventTable)",
-            database: IntegrationTests.targetDatabase)
+            database: IntegrationTests.TargetDatabase)
         for event in eventRecords {
             if (event[1] as! String == "in_session_event") {
                 XCTAssertEqual(event[0] as? String, sessionId)

--- a/TreasureDataTests/IntegrationTests.swift
+++ b/TreasureDataTests/IntegrationTests.swift
@@ -21,10 +21,15 @@ class IntegrationTests: XCTestCase {
     var tempTables: [String] = []
 
     override class func setUp() {
-        apiKey = ProcessInfo.processInfo.environment["API_MASTER_KEY"]
-        apiEndpoint = ProcessInfo.processInfo.environment["API_ENDPOINT"]
+        guard let apiKey = ProcessInfo.processInfo.environment["API_MASTER_KEY"] else {
+            fatalError("Missing env API_MASTER_KEY")
+        }
+        guard let apiEndpoint = ProcessInfo.processInfo.environment["API_ENDPOINT"] else {
+            fatalError("Missing env API_ENDPOINT")
+        }
 
-        api = TDAPI.init(endpoint: "API_ENDPOINT", apiKey: apiKey)
+        IntegrationTests.apiKey = apiKey
+        api = TDAPI.init(endpoint: apiEndpoint, apiKey: apiKey)
         if (!(try! api.isDatabaseExist(TargetDatabase))) {
             fatalError("Either the apiKey is invalid or the target database \(TargetDatabase) is not exist!")
         }

--- a/TreasureDataTests/IntegrationTests.swift
+++ b/TreasureDataTests/IntegrationTests.swift
@@ -124,6 +124,20 @@ class IntegrationTests: XCTestCase {
         }
     }
 
+    func testResetUniqId() {
+        sdkClient.enableCustomEvent()
+        sdkClient.enableAutoAppendUniqId()
+
+        let table = newTempTable()
+        sdkClient.addEvent([:], table: table)
+        sdkClient.resetUniqId()
+        sdkClient.addEvent([:], table: table)
+        sdkClient.uploadEvents()
+
+        let result = try! IntegrationTests.api.stubbornQuery("select td_uuid from \(table) limit 2", database: IntegrationTests.TargetDatabase)
+        XCTAssert(result[0][0] as! String != result[1][0] as! String)
+    }
+
     private func newTempTable() -> String {
         let table: String = "ios_integration_test_" + NSUUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "_")
         tempTables.append(table)

--- a/TreasureDataTests/TDAPI.swift
+++ b/TreasureDataTests/TDAPI.swift
@@ -1,0 +1,216 @@
+//
+//  TDAPI.swift
+//  TreasureDataTests
+//
+//  Created by huylenq on 1/27/19.
+//  Copyright © 2019 Treasure Data. All rights reserved.
+//
+
+import Foundation
+
+/*!
+ * Naive and adhoc API client to TreasureData, only serve for test cases verifying purpose
+ */
+class TDAPI {
+    let apiKey: String
+    let endpoint: String
+    let debug: Bool
+
+    enum TDAPIError: Error {
+        case jobError(String)
+        case queryError(String)
+        case operationError(String)
+        case timeoutError(String)
+    }
+
+    init(endpoint: String = "https://api-development.treasuredata.com", apiKey: String, debug: Bool = false) {
+        self.endpoint = endpoint
+        self.apiKey = apiKey
+        self.debug = debug
+    }
+
+    func waitForJob(jobID: String) throws {
+        var jobStatus: String?
+        jobStatus = getJobStatus(jobID: jobID)
+        while jobStatus == nil || jobStatus == "running" || jobStatus == "queued" {
+            Thread.sleep(forTimeInterval: 5)
+            jobStatus = getJobStatus(jobID: jobID)
+        }
+        if jobStatus != "success" {
+            throw TDAPIError.jobError("Job \(jobID) was failed for some reason!")
+        }
+    }
+
+    func getJobStatus(jobID: String) -> String {
+        let (_, job) = getAsJSON("v3/job/status/\(jobID)")
+        return job!["status"] as! String
+    }
+
+    func query(_ query: String, database: String) throws -> [[Any]] {
+        let (_, queryResp) = post(
+                "v3/job/issue/hive/\(database)",
+                params: ["query": query])
+        let jobID = queryResp!["job_id"] as! String
+        do {
+            try waitForJob(jobID: jobID)
+        } catch {
+            throw TDAPIError.queryError("Failed to execute query '\(query)'")
+        }
+        let (_, jobResultData) = get("v3/job/result/\(jobID)")
+        return String(data: jobResultData!, encoding: .utf8)!
+                .components(separatedBy: .newlines)
+                .filter {
+                    $0.count > 0
+                }
+                .map {
+                    (line: String) -> Any in
+                    return line.components(separatedBy: ",")
+                } as! [[Any]]
+    }
+
+    /*!
+     * Retry query until succeed
+     *
+     * - Parameter timeout: timeout in seconds, default is 15 minutes
+     */
+    func stubbornQuery(_ query: String, database: String, timeout: TimeInterval = 15 * 60) throws -> [[Any]] {
+        let started = Date()
+
+        func doRetry(_ query: String, database: String) throws -> [[Any]] {
+            if abs(started.timeIntervalSinceNow) > timeout {
+                throw TDAPIError.timeoutError("Took too long (more than \(timeout) seconds) to execute query '\(query)'")
+            }
+            do {
+                return try self.query(query, database: database)
+            } catch TDAPIError.queryError {
+                return try doRetry(query, database: database)
+            } catch {
+                fatalError()
+            }
+        }
+
+        return try doRetry(query, database: database)
+    }
+    
+    /*!
+     * Return a list of table name
+     */
+    public func listTables(database: String) -> [String] {
+        let (_, data) = getAsJSON("v3/table/list/\(database)")
+        return (data!["tables"] as! [[String: Any]]).map { (table: [String: Any]) in table["name"] as! String }
+    }
+    
+    public func deleteTable(database: String, table: String) throws {
+        let (status, _) = post("v3/table/delete/\(database)/\(table)")
+        if (status != 200) {
+            throw TDAPIError.operationError("Unable to delete the table \(database).\(table)")
+        }
+    }
+    
+    public func isDatabaseExist(_ database: String) throws -> Bool {
+        // Simply prope for table lists, consider database is unexist if the request fails
+        let (status, _) = get("v3/table/list/\(database)")
+        switch status {
+        case 200: return true
+        case 404: return false
+        default:
+            throw TDAPIError.operationError("Unrecognized status code repsonse from 'v3/table/list/\(database)")
+        }
+    }
+
+    private func getAsJSON(_ path: String) -> (Int, [String: Any]?) {
+        let (status, data) = get(path)
+        return (status, try! JSONSerialization.jsonObject(with: data!, options: []) as! [String: Any])
+    }
+    
+    /*!
+     * Synchronously do a GET request
+     */
+    private func get(_ path: String, headers: [String: String] = [:]) -> (Int, Data?) {
+        var req: URLRequest = URLRequest(url: URL(string: "\(endpoint)/\(path)")!)
+        req.httpMethod = "GET"
+        req.setValue("TD1 \(apiKey)", forHTTPHeaderField: "Authorization")
+
+        var status: Int?
+        var respData: Data?
+
+        headers.forEach {
+            req.setValue($1, forHTTPHeaderField: $0)
+        }
+
+        let semaphore = DispatchSemaphore(value: 0)
+
+        if debug {
+            print("[TDAPI] Request: \(req.httpMethod!) \(req.url!.absoluteString)")
+        }
+
+        let dataTask: URLSessionDataTask = URLSession.shared.dataTask(with: req) {
+            data, response, error in
+            let httpResponse: HTTPURLResponse = response as! HTTPURLResponse;
+            status = httpResponse.statusCode
+            if (httpResponse.statusCode == 200) {
+                print("[TDAPI] Response: \(status!) - \(NSString(data: data!, encoding: String.Encoding.utf8.rawValue)!)")
+                respData = data
+                semaphore.signal()
+            } else {
+                print("[TDAPI] ERROR Response: \(status!)")
+                semaphore.signal();
+            }
+        }
+        dataTask.resume()
+
+        _ = semaphore.wait(timeout: .distantFuture)
+        return (status!, respData)
+    }
+
+    /*!
+     * Synchronously do a POST request
+     */
+    private func post(_ path: String, params: [String: String] = [:], headers: [String: String] = [:]) -> (Int, [String: Any]?) {
+        var req: URLRequest = URLRequest(url: URL(string: "\(endpoint)/\(path)")!)
+        req.httpMethod = "POST"
+        req.setValue("TD1 \(apiKey)", forHTTPHeaderField: "Authorization")
+
+        headers.forEach {
+            req.setValue($1, forHTTPHeaderField: $0)
+        }
+        req.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+
+        var reqParams = URLComponents()
+        reqParams.queryItems = params.map {
+            param in
+            URLQueryItem(name: param.key, value: param.value)
+        }
+        var encodedParams = reqParams.url!.relativeString
+        encodedParams = String(encodedParams[encodedParams.index(encodedParams.startIndex, offsetBy: 1)...])
+        req.httpBody = encodedParams.data(using: .utf8)
+
+        var status: Int?
+        var respData: [String: Any]?
+        let semaphore = DispatchSemaphore(value: 0)
+
+        if debug {
+            print("[TDAPI] Request: \(req.httpMethod!) \(req.url!.absoluteString) - \(encodedParams)")
+        }
+
+        let dataTask: URLSessionDataTask = URLSession.shared.dataTask(with: req) {
+            data, response, error in
+            let httpResponse: HTTPURLResponse = response as! HTTPURLResponse;
+            status = httpResponse.statusCode
+            if (httpResponse.statusCode == 200) {
+                if self.debug {
+                    print("[TDAPI] Received response \(status!) - \(NSString(data: data!, encoding: String.Encoding.utf8.rawValue)!)\n")
+                }
+                respData = try! JSONSerialization.jsonObject(with: data!, options: []) as! [String: Any]
+                semaphore.signal()
+            } else {
+                print("[TDAPI] Error response - \(status!)")
+                semaphore.signal();
+            }
+        }
+        dataTask.resume()
+
+        _ = semaphore.wait(timeout: .distantFuture)
+        return (status!, respData)
+    }
+}

--- a/TreasureDataTests/TreasureDataTests-Bridging-Header.h
+++ b/TreasureDataTests/TreasureDataTests-Bridging-Header.h
@@ -1,0 +1,5 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+
+#import "TreasureData.h"

--- a/scripts/ci_pod_install
+++ b/scripts/ci_pod_install
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ -d "$HOME/.cocoapods/repos/master" ]; then
+    echo Local CocoaPods repo has been restored from cache
+    # Not sure if caching for Pods that fetched from CircleCI's S3 is a wise choice,
+    # seems like a doubly layered caching.
+else
+    curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf
+fi
+
+pod install
+
+exit 0

--- a/scripts/ci_test
+++ b/scripts/ci_test
@@ -22,7 +22,7 @@ xcodebuild \
 
 test_status=$?
 
-mv ./build/reports/junit.xml "$3"
+mv ./build/reports/junit.xml "$TEST_RESULTS_FILE"
 
 if [ $test_status -ne 0 ]; then
     exit $test_status

--- a/scripts/ci_test
+++ b/scripts/ci_test
@@ -1,18 +1,31 @@
 #!/usr/bin/env bash
 
-set -eo pipefail
+set -o pipefail
 
-destination="$1"
-log_file="$2"
+DESTINATION="$1"
+LOG_FILE="$2"
+TEST_RESULTS_FILE="$3"
+
+cd "$(dirname "$(dirname "${BASH_SOURCE[0]}")")"
 
 xcodebuild \
     -workspace TreasureData.xcworkspace \
     -scheme TreasureData \
     -sdk iphonesimulator \
     -disable-concurrent-destination-testing \
-    -destination "$destination" \
-    TD_DEV_MASTER_KEY=${TD_DEV_MASTER_KEY} \
+    -destination "$DESTINATION" \
+    TD_DEV_MASTER_KEY="$TD_DEV_MASTER_KEY" \
     test \
-    | sed 's/^\(.*TD_DEV_MASTER_KEY[[:space:]]*=[[:space:]]*\)\([[:<:]].*[[:>:]]\)\(.*\)$/\1XXXXXXXXXXX\3/' \
-    | tee "$log_file" \
-    | xcpretty
+    | gsed -u '1,100s/^\(.*TD_DEV_MASTER_KEY\s*=\s*\)\(\b.*\b\)\(.*\)$/\1XXXXXXXXXXX\3/g' \
+    | tee "$LOG_FILE" \
+    | xcpretty --report junit
+
+test_status=$?
+
+mv ./build/reports/junit.xml "$3"
+
+if [ $test_status -ne 0 ]; then
+    exit $test_status
+fi
+
+exit 0

--- a/scripts/ci_test
+++ b/scripts/ci_test
@@ -24,8 +24,4 @@ test_status=$?
 
 mv ./build/reports/junit.xml "$TEST_RESULTS_FILE"
 
-if [ $test_status -ne 0 ]; then
-    exit $test_status
-fi
-
-exit 0
+exit $test_status

--- a/scripts/ci_test
+++ b/scripts/ci_test
@@ -14,9 +14,10 @@ xcodebuild \
     -sdk iphonesimulator \
     -disable-concurrent-destination-testing \
     -destination "$DESTINATION" \
-    TD_DEV_MASTER_KEY="$TD_DEV_MASTER_KEY" \
+    API_ENDPOINT="$API_ENDPOINT" \
+    API_MASTER_KEY="$API_MASTER_KEY" \
     test \
-    | gsed -u '1,100s/^\(.*TD_DEV_MASTER_KEY\s*=\s*\)\(\b.*\b\)\(.*\)$/\1XXXXXXXXXXX\3/g' \
+    | gsed -u '1,100s/^\(.*API_MASTER_KEY\s*=\s*\)\(\b.*\b\)\(.*\)$/\1XXXXXXXXXXX\3/g' \
     | tee "$LOG_FILE" \
     | xcpretty --report junit
 

--- a/scripts/ci_test
+++ b/scripts/ci_test
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+destination="$1"
+log_file="$2"
+
+xcodebuild \
+    -workspace TreasureData.xcworkspace \
+    -scheme TreasureData \
+    -sdk iphonesimulator \
+    -disable-concurrent-destination-testing \
+    -destination "$destination" \
+    TD_DEV_MASTER_KEY=${TD_DEV_MASTER_KEY} \
+    test \
+    | sed 's/^\(.*TD_DEV_MASTER_KEY[[:space:]]*=[[:space:]]*\)\([[:<:]].*[[:>:]]\)\(.*\)$/\1XXXXXXXXXXX\3/' \
+    | tee "$log_file" \
+    | xcpretty

--- a/scripts/ci_test
+++ b/scripts/ci_test
@@ -14,8 +14,9 @@ xcodebuild \
     -sdk iphonesimulator \
     -disable-concurrent-destination-testing \
     -destination "$DESTINATION" \
-    API_ENDPOINT="$API_ENDPOINT" \
     API_MASTER_KEY="$API_MASTER_KEY" \
+    API_ENDPOINT="$API_ENDPOINT" \
+    COLLECTOR_ENDPOINT="$COLLECTOR_ENDPOINT" \
     test \
     | gsed -u '1,100s/^\(.*API_MASTER_KEY\s*=\s*\)\(\b.*\b\)\(.*\)$/\1XXXXXXXXXXX\3/g' \
     | tee "$LOG_FILE" \


### PR DESCRIPTION
Main changes are:

- Added `IntegrationTests.swift` along with the adhoc API client `TDAPI.swift`
- Reconfiguration of CircleCI `~/.circleci/config.yml` along with `scripts/ci_test` and `scripts/ci_pod_install`

The PR's diffs have a lot of noises due to the new `TestHost` app target (a necessity to able to test for app lifecycle events).