### PR TITLE
Add check for StoreKit availability

### DIFF
--- a/TreasureData/TDUtils.h
+++ b/TreasureData/TDUtils.h
@@ -36,4 +36,6 @@ static NSString *const TDEventClassIAP = @"iap";
 
 + (BOOL)isRunningWithUnity;
 
++ (BOOL)isStoreKitAvailable;
+
 @end

--- a/TreasureData/TDUtils.m
+++ b/TreasureData/TDUtils.m
@@ -75,4 +75,13 @@
     return [[NSUserDefaults standardUserDefaults] boolForKey:TD_USER_DEFAULTS_KEY_IS_UNITY];
 }
 
++ (BOOL)isStoreKitAvailable {
+    for (NSBundle *bundle in NSBundle.allFrameworks) {
+        if ([bundle classNamed:@"SKStoreProductViewController"]) {
+            return YES;
+        }
+    }
+    return NO;
+}
+
 @end

--- a/TreasureData/TreasureData.m
+++ b/TreasureData/TreasureData.m
@@ -104,9 +104,6 @@ static long sessionTimeoutMilli = -1;
             KCLog(@"Failed to initialize client");
         }
         [self observeLifecycleEvents];
-        if (self.isInAppPurchaseEventEnabled) {
-            _iapObserver = [[TDIAPObserver alloc] initWithTD:self];
-        }
     }
     return self;
 }
@@ -625,8 +622,14 @@ static long sessionTimeoutMilli = -1;
 }
 
 - (void)enableInAppPurchaseEvent {
-    self.inAppPurchaseEnabled = YES;
-    _iapObserver = [[TDIAPObserver alloc] initWithTD:self];
+    if ([TDUtils isStoreKitAvailable]) {
+        self.inAppPurchaseEnabled = YES;
+        if (!_iapObserver) {
+            _iapObserver = [[TDIAPObserver alloc] initWithTD:self];
+        }
+    } else {
+        NSLog(@"WARN: Unable to enable IAP tracking as StoreKit is not available for this application!");
+    }
 }
 
 - (void)disableInAppPurchaseEvent {


### PR DESCRIPTION
All apps created now always have IAP enabled (could not turn off).
This adds a just-to-be-sure check for if the app is (dynamically) linked with StoreKit library.