### PR TITLE
Reduce tests' request rate and increase CI timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,7 @@ jobs:
       - *save_pods_cache
       - run:
           name: Test on iOS 12
+          no_output_timeout: 1800
           command: ./scripts/ci_test 'platform=iOS Simulator,name=iPhone 7,OS=12.2' logs/xcbuild_ios_12.log test_results/ios_12.xml
       - *store_artifacts
       - *store_test_results
@@ -65,8 +66,9 @@ jobs:
       - *install_pods
       - *save_pods_cache
       - run:
-          name: Test on iOS 10
-          command: ./scripts/ci_test 'platform=iOS Simulator,name=iPhone 7,OS=10.3.1' logs/xcbuild_ios_10.log test_results/ios_10.xml
+          name: Test on iOS 11
+          no_output_timeout: 1800
+          command: ./scripts/ci_test 'platform=iOS Simulator,name=iPhone 7,OS=11.2' logs/xcbuild_ios_10.log test_results/ios_10.xml
       - *store_artifacts
       - *store_test_results
 
@@ -82,6 +84,7 @@ jobs:
       - *save_pods_cache
       - run:
           name: Test on iOS 10
+          no_output_timeout: 1800
           command: ./scripts/ci_test 'platform=iOS Simulator,name=iPhone 7,OS=10.3.1' logs/xcbuild_ios_10.log test_results/ios_10.xml
       - *store_artifacts
       - *store_test_results

--- a/TreasureDataTests/TDAPI.swift
+++ b/TreasureDataTests/TDAPI.swift
@@ -83,6 +83,7 @@ class TDAPI {
             do {
                 return try self.query(query, database: database)
             } catch TDAPIError.queryError {
+                Thread.sleep(forTimeInterval: 10)
                 return try doRetry(query, database: database)
             } catch {
                 fatalError()


### PR DESCRIPTION
https://circleci.com/gh/treasure-data/td-ios-sdk/209 failed due to running time for a single event lapped over 10 minutes.
This only tweaks CI steps timeout parameters and requests interval for those integration tests, no changes on the SDK library itself.