### PR TITLE
Release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Version 0.6.0
+_2020-06-15_
+
+* Use SHA-256 algorithm instead of MD5 algorithm to generate project id for cache data in Keen client
+
 ## Version 0.5.0
 _2020-04-28_
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Finally, execute 'pod install'.
 $ pod install
 ```
 
+Remember to reopen your project by opening .xcworkspace file instead of .xcodeproj file 
+
 ### Framework
 
 Download [TreasureData.framework](http://cdn.treasuredata.com/sdk/ios/0.5.0/TreasureData-iOS-SDK.framework.zip) and add it and `libz` library into your project.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $ gem install cocoapods
 Next, add this line in your Podfile.
 
 ```
-pod 'TreasureData-iOS-SDK', '= 0.5.0'
+pod 'TreasureData-iOS-SDK', '= 0.6.0'
 ```
 
 If you use the SDK in Swift, add this line to your Podfile.
@@ -38,7 +38,7 @@ Remember to reopen your project by opening .xcworkspace file instead of .xcodepr
 
 ### Framework
 
-Download [TreasureData.framework](http://cdn.treasuredata.com/sdk/ios/0.5.0/TreasureData-iOS-SDK.framework.zip) and add it and `libz` library into your project.
+Download [TreasureData.framework](http://cdn.treasuredata.com/sdk/ios/0.6.0/TreasureData-iOS-SDK.framework.zip) and add it and `libz` library into your project.
 
 ## Usage in Objective-C
 

--- a/TreasureData-iOS-SDK.podspec
+++ b/TreasureData-iOS-SDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "TreasureData-iOS-SDK"
-  s.version      = "0.5.0"
+  s.version      = "0.6.0"
   s.summary      = "TreasureData SDK for iOS."
   s.license      = "Apache"
   s.authors      = { "mitsu" => "mitsu@treasure-data.com",

--- a/TreasureData/TDClient.m
+++ b/TreasureData/TDClient.m
@@ -50,13 +50,13 @@ static NSString *version = @"0.5.0";
 }
 
 - (NSString *)sha256Hash:(NSString *)input {
-    // Generate a cryptographic digest using the secure SHA-512 algorithm
+    // Generate a cryptographic digest using the secure SHA-256 algorithm
     const char* cString = [input UTF8String];
     unsigned char hashedString[CC_SHA256_DIGEST_LENGTH];
     CC_SHA256(cString, (CC_LONG) strlen(cString), hashedString);
 
     // Convert the digest to an NSString hex-string for straightforward use
-    NSMutableString *nsString = [NSMutableString stringWithCapacity:CC_SHA256_DIGEST_LENGTH];
+    NSMutableString *nsString = [NSMutableString stringWithCapacity:CC_SHA256_DIGEST_LENGTH * 2];
     for (int i = 0; i < CC_SHA256_DIGEST_LENGTH; i++) {
         [nsString appendFormat:@"%02x", hashedString[i]];
     }

--- a/TreasureData/TDClient.m
+++ b/TreasureData/TDClient.m
@@ -13,7 +13,7 @@
 #import "Deflate.h"
 #import "TDClient.h"
 
-static NSString *version = @"0.5.0";
+static NSString *version = @"0.6.0";
 
 @implementation TDClient
 

--- a/TreasureData/TDClient.m
+++ b/TreasureData/TDClient.m
@@ -23,7 +23,7 @@ static NSString *version = @"0.5.0";
 }
 
 - (id)__initWithApiKey:(NSString *)apiKey apiEndpoint:(NSString*)apiEndpoint {
-    NSString *projectId = [NSString stringWithFormat:@"_td %@", [self md5:apiKey]];
+    NSString *projectId = [NSString stringWithFormat:@"_td %@", [self sha256Hash:apiKey]];
     self = [self initWithProjectId:projectId andWriteKey:@"dummy_write_key" andReadKey:@"dummy_read_key"];
     self.apiKey = apiKey;
     self.apiEndpoint = apiEndpoint;
@@ -49,18 +49,19 @@ static NSString *version = @"0.5.0";
     return self;
 }
 
-- (NSString *)md5:(NSString *)input
-{
-    const char *cStr = [input UTF8String];
-    unsigned char digest[16];
-    CC_MD5(cStr, (CC_LONG)strlen(cStr), digest);
-    
-    NSMutableString *output = [NSMutableString stringWithCapacity:CC_MD5_DIGEST_LENGTH * 2];
-    
-    for(int i = 0; i < CC_MD5_DIGEST_LENGTH; i++)
-        [output appendFormat:@"%02x", digest[i]];
-    
-    return output;
+- (NSString *)sha256Hash:(NSString *)input {
+    // Generate a cryptographic digest using the secure SHA-512 algorithm
+    const char* cString = [input UTF8String];
+    unsigned char hashedString[CC_SHA256_DIGEST_LENGTH];
+    CC_SHA256(cString, (CC_LONG) strlen(cString), hashedString);
+
+    // Convert the digest to an NSString hex-string for straightforward use
+    NSMutableString *nsString = [NSMutableString stringWithCapacity:CC_SHA256_DIGEST_LENGTH];
+    for (int i = 0; i < CC_SHA256_DIGEST_LENGTH; i++) {
+        [nsString appendFormat:@"%02x", hashedString[i]];
+    }
+
+    return nsString;
 }
 
 - (void)sendEvents:(NSData *)data completionHandler:(void (^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler {


### PR DESCRIPTION
Use SHA-256 algorithm instead of MD5 algorithm to generate project id for cache data in Keen client