### PR TITLE
Reset global session id

### DIFF
--- a/TreasureData/Session.h
+++ b/TreasureData/Session.h
@@ -16,6 +16,7 @@
 - (void) start;
 - (void) finish;
 - (NSString*) getId;
+- (void)resetId;
 @end
 
 #endif /* Session_h */

--- a/TreasureData/Session.m
+++ b/TreasureData/Session.m
@@ -43,4 +43,8 @@ static int DEFAULT_SESSION_PENDING_MILLIS = 10 * 1000;
     }
     return self.id;
 }
+
+- (void)resetId {
+    self.id = [[NSUUID UUID] UUIDString];
+}
 @end

--- a/TreasureData/TreasureData.h
+++ b/TreasureData/TreasureData.h
@@ -361,6 +361,11 @@ typedef void (^ErrorHandler)(NSString* _Nonnull errorCode, NSString* _Nullable e
 + (NSString* _Nullable)getSessionId;
 
 /**
+ * Reset static session. This will force create a new session when static method `startSession` is called.
+ */
++ (void)resetSessionId;
+
+/**
  * Set the minimal time window that the static session stays alive.
  *
  * @param to The session timeout, default is 10 seconds

--- a/TreasureData/TreasureData.m
+++ b/TreasureData/TreasureData.m
@@ -529,6 +529,10 @@ static NSString *TreasureDataErrorDomain = @"com.treasuredata";
     return [session getId];
 }
 
++ (void)resetSessionId {
+    [session resetId];
+}
+
 + (void)setSessionTimeoutMilli:(long)to {
     sessionTimeoutMilli = to;
 }


### PR DESCRIPTION
Provide a way to reset global session id when user call global `startSession` inside `sessionPendingMilli` duration from previous global `endSession`; in essence, bypass all start and end session logic to reset session id.