### PR TITLE
Fix create framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ UserInterfaceState.xcuserstate
 TreasureDataExample/Podfile.lock
 TreasureDataExampleSwift/Podfile.lock
 build
+Output

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -7,7 +7,7 @@ DEPENDENCIES:
   - KeenClientTD (= 3.2.35)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  https://cdn.cocoapods.org/:
     - KeenClientTD
 
 SPEC CHECKSUMS:
@@ -15,4 +15,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 7148f57bcf4b8488673f52ee710cf2de23769865
 
-COCOAPODS: 1.7.5
+COCOAPODS: 1.9.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -7,7 +7,7 @@ DEPENDENCIES:
   - KeenClientTD (= 3.2.35)
 
 SPEC REPOS:
-  https://cdn.cocoapods.org/:
+  https://github.com/cocoapods/specs.git:
     - KeenClientTD
 
 SPEC CHECKSUMS:
@@ -15,4 +15,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 7148f57bcf4b8488673f52ee710cf2de23769865
 
-COCOAPODS: 1.9.3
+COCOAPODS: 1.7.5

--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ task :build_for_device do
 end
 
 task :build_for_simulator do
-  sh('xcodebuild -workspace TreasureData.xcworkspace -scheme TreasureData -configuration Release -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 11" SYMROOT=$(PWD)/Output OTHER_CFLAGS="-fembed-bitcode" CLANG_ENABLE_MODULE_DEBUGGING=NO GCC_PRECOMPILE_PREFIX_HEADER=NO DEBUG_INFORMATION_FORMAT="DWARF with dSYM"')
+  sh('xcodebuild -workspace TreasureData.xcworkspace -scheme TreasureData -configuration Release -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 11" ARCHS="i368 x86_64" ONLY_ACTIVE_ARCH=NO SYMROOT=$(PWD)/Output OTHER_CFLAGS="-fembed-bitcode" CLANG_ENABLE_MODULE_DEBUGGING=NO GCC_PRECOMPILE_PREFIX_HEADER=NO DEBUG_INFORMATION_FORMAT="DWARF with dSYM"')
   sh('cd Output/Release-iphonesimulator && ln -s KeenClientTD/libKeenClientTD.a libKeenClientTD.a')
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -108,10 +108,8 @@ def create_universal_library(output_dir)
 end
 
 def copy_header_file(output_dir)
-  keen_header_dir = File.join(output_dir, 'KeenClientTD')
-  mkdir_p(keen_header_dir)
   sh("cp -p Output/Release-iphoneos/include/TreasureData/* #{output_dir}")
-  sh("cp -p Output/Release-iphoneos/KeenClientTD/*.h #{keen_header_dir}")
+  sh("cp -RL Pods/Headers/Public/. #{output_dir}")
 end
 
 def create_info_plist(output_dir)

--- a/TreasureData.xcodeproj/project.pbxproj
+++ b/TreasureData.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		6BF8C92F1A3E972C005B1804 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6BF8C92E1A3E972C005B1804 /* Security.framework */; };
 		6BF8C9311A3E977B005B1804 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 6BF8C9301A3E977B005B1804 /* libz.dylib */; };
 		6BF8C9341A3E9B76005B1804 /* TDClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BF8C9331A3E9B76005B1804 /* TDClient.m */; };
+		DF1DA0DA251DE468006EE00F /* TDRequestOptionsKey.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = DF259EBC22A5034A00697319 /* TDRequestOptionsKey.h */; };
 		DF9D4DC6230FBC4200682E41 /* AdSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DF9D4DC5230FBC4200682E41 /* AdSupport.framework */; };
 		E52CB7F521FDD78A00062EBA /* TDAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = E52CB7F421FDD78A00062EBA /* TDAPI.swift */; };
 		E5A84B5421FEA35300BC699D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5A84B5321FEA35300BC699D /* AppDelegate.swift */; };
@@ -62,6 +63,7 @@
 			dstPath = "include/$(PRODUCT_NAME)";
 			dstSubfolderSpec = 16;
 			files = (
+				DF1DA0DA251DE468006EE00F /* TDRequestOptionsKey.h in CopyFiles */,
 				6B738097192A09160097D56E /* TreasureData.h in CopyFiles */,
 				6B758E4E1C00C59A00D597F8 /* TDClient.h in CopyFiles */,
 			);


### PR DESCRIPTION
Fix for creating framework and package, including:
- Correctly add missing header files
- Exclude duplicated arm architecture in output simulator library

Other:
- Ignore Output folder