### PR TITLE
Ad tracking transparency example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Treasure Data iOS SDK
 ===============
 
-iOS SDK for [Treasure Data](http://www.treasuredata.com/). With this SDK, you can import the events on your applications into Treasure Data easily. Technically, this library supports iOS 7 and later, but we only execute OS coverage tests for iOS 8, 9, 10, 11, 12 and 13.
+iOS SDK for [Treasure Data](http://www.treasuredata.com/). With this SDK, you can import the events on your applications into Treasure Data easily. Technically, this library supports iOS 7 and later, but we only execute OS coverage tests for iOS 8, 9, 10, 11, 12, 13 and 14.
 
 Also, there is an alternative SDK written in Swift [https://github.com/recruit-lifestyle/TreasureDataSDK](https://github.com/recruit-lifestyle/TreasureDataSDK). Note, however, that it does not support current GDPR functionality in the mainstream TD SDKs.
 

--- a/README.md
+++ b/README.md
@@ -314,7 +314,12 @@ UUID will be added to each event record automatically if you call `enableAutoApp
 It outputs the value as a column name `record_uuid` by default.
 
 ### Adding Advertising Id to each event record automatically
-Advertising Id will be added to each event record automatically if you call `enableAutoAppendAdvertisingIdentifier`. You must link Ad Support framework in Link Binary With Libraries build phase for this feature to work. User must also not turn on Limit Ad Tracking feature in their iOS device, otherwise Treasure Data will send zero filled string as the advertising id (the value we get from Ad Support framework).
+Advertising Id will be added to each event record automatically if you call `enableAutoAppendAdvertisingIdentifier`.
+
+You must link Ad Support framework in Link Binary With Libraries build phase for this feature to work. User must also not turn on Limit Ad Tracking feature in their iOS device, otherwise Treasure Data will send zero filled string as the advertising id (the value we get from Ad Support framework).
+
+Starting in iOS 14, you will have to explicitly request user's permission for advertising identifier using AppTrackingTransparency framework. Consult Apple official documentation for AppTrackingTransparency on how to implement this requirement.
+
 If you turn on this feature, keep in mind that you will have to declare correct reason for getting advertising identifier when you submit your app for review to the App Store.
 
 ```

--- a/TreasureDataExample/TreasureDataExample.xcodeproj/project.pbxproj
+++ b/TreasureDataExample/TreasureDataExample.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		6B14FEEF1D3624DA00E9C3AF /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6B14FEED1D3624DA00E9C3AF /* Main.storyboard */; };
 		6B14FEF41D3624DA00E9C3AF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6B14FEF21D3624DA00E9C3AF /* LaunchScreen.storyboard */; };
 		ACC8A425266E84EF5E9033F4 /* libPods-TreasureDataExample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F5DD3B4DAFF3BD9DE0273623 /* libPods-TreasureDataExample.a */; settings = {ATTRIBUTES = (Required, ); }; };
+		DF0ED81B252B4DE4008F58B5 /* AdSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DF0ED81A252B4DE4008F58B5 /* AdSupport.framework */; };
 		E58437E1224A36D2009F0C7F /* IAPViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E58437E0224A36D2009F0C7F /* IAPViewController.swift */; };
 /* End PBXBuildFile section */
 
@@ -33,6 +34,7 @@
 		6B14FEF31D3624DA00E9C3AF /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		6B14FEF51D3624DA00E9C3AF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D756E6DA689C821E31575BDE /* Pods-TreasureDataExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TreasureDataExample.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TreasureDataExample/Pods-TreasureDataExample.debug.xcconfig"; sourceTree = "<group>"; };
+		DF0ED81A252B4DE4008F58B5 /* AdSupport.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdSupport.framework; path = System/Library/Frameworks/AdSupport.framework; sourceTree = SDKROOT; };
 		E58437DF224A36D1009F0C7F /* TreasureDataExample-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "TreasureDataExample-Bridging-Header.h"; sourceTree = "<group>"; };
 		E58437E0224A36D2009F0C7F /* IAPViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IAPViewController.swift; sourceTree = "<group>"; };
 		F5DD3B4DAFF3BD9DE0273623 /* libPods-TreasureDataExample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-TreasureDataExample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -44,6 +46,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				ACC8A425266E84EF5E9033F4 /* libPods-TreasureDataExample.a in Frameworks */,
+				DF0ED81B252B4DE4008F58B5 /* AdSupport.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -53,6 +56,7 @@
 		16695A7E935BB39E4AA99D6B /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				DF0ED81A252B4DE4008F58B5 /* AdSupport.framework */,
 				F5DD3B4DAFF3BD9DE0273623 /* libPods-TreasureDataExample.a */,
 			);
 			name = Frameworks;

--- a/TreasureDataExample/TreasureDataExample/Info.plist
+++ b/TreasureDataExample/TreasureDataExample/Info.plist
@@ -24,6 +24,8 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSUserTrackingUsageDescription</key>
+	<string>App is tracking user for demonstration purposes</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/TreasureDataExample/TreasureDataExample/TreasureDataExample.h
+++ b/TreasureDataExample/TreasureDataExample/TreasureDataExample.h
@@ -20,5 +20,6 @@
 
 + (NSSet<NSString *> *)productIds;
 
++ (void)requestAppTrackingAuthorizationIfNeeded;
 
 @end

--- a/TreasureDataExample/TreasureDataExample/TreasureDataExample.m
+++ b/TreasureDataExample/TreasureDataExample/TreasureDataExample.m
@@ -10,6 +10,7 @@
 
 #import "TreasureData.h"
 #import "TreasureDataExample.h"
+@import AppTrackingTransparency;
 
 @implementation TreasureDataExample
 
@@ -31,6 +32,16 @@ static NSString *testTable;
     [[TreasureData sharedInstance] enableServerSideUploadTimestamp:@"server_upload_time"];
     [[TreasureData sharedInstance] enableInAppPurchaseEvent];
     [[TreasureData sharedInstance] enableAutoAppendAdvertisingIdentifier:@"td_maid"];
+}
+
++ (void)requestAppTrackingAuthorizationIfNeeded {
+    if (@available(iOS 14, *)) {
+        [ATTrackingManager requestTrackingAuthorizationWithCompletionHandler:^(ATTrackingManagerAuthorizationStatus status) {
+            NSLog(@"app tracking status %lu", (unsigned long)status);
+        }];
+    } else {
+        // No need to request app tracking authorization
+    }
 }
 
 + (NSString *)testTable {

--- a/TreasureDataExample/TreasureDataExample/ViewController.m
+++ b/TreasureDataExample/TreasureDataExample/ViewController.m
@@ -37,6 +37,8 @@
     [self customEventSwitchChanged:self.customEventSwitch];
     [self appLifecycleEventSwitchChanged:self.appLifecycleEventSwitch];
     [self iapEventSwitchChanged:self.iapEventSwitch];
+    
+    [TreasureDataExample requestAppTrackingAuthorizationIfNeeded];
 }
 
 - (void)didReceiveMemoryWarning {


### PR DESCRIPTION
### Why
Starting in iOS 14, Apple requires app to explicitly ask for user's permission for advertising identifier via AppTrackingTransparency framework. This PR has two things:
- Update README to support iOS 14
- Add documentation in README clarifying this issue.
- Add to example app code on how to implement asking for user's permission using AppTrackingTransparency