### PR TITLE
Update link to Treasure Data Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Download [TreasureData.framework](http://cdn.treasuredata.com/sdk/ios/0.8.0/Trea
 
 ## Usage in Objective-C
 
-- [Treasure Data's Guide](https://support.treasuredata.com/hc/en-us/articles/360000671667-iOS-SDK) (most parts are overlap with this README)
+- [Treasure Data's Guide](https://docs.treasuredata.com/display/public/PD/iOS+SDK) (most parts are overlap with this README)
 - [API Reference](https://treasure-data.github.io/td-ios-sdk/Classes/TreasureData.html)
 
 ### Import SDK header file

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Download [TreasureData.framework](http://cdn.treasuredata.com/sdk/ios/0.8.0/Trea
 
 ## Usage in Objective-C
 
-- [Treasure Data's Guide](https://docs.treasuredata.com/display/public/PD/iOS+SDK) (most parts are overlap with this README)
+- [Treasure Data's Guide](https://docs.treasuredata.com/display/public/PD/iOS+SDK) (most parts overlap with this README)
 - [API Reference](https://treasure-data.github.io/td-ios-sdk/Classes/TreasureData.html)
 
 ### Import SDK header file


### PR DESCRIPTION
Our Product Documentation have been moved to: https://go.treasuredata.com/docs which again redirects to: https://docs.treasuredata.com/display/public/PD/Product+Documentation+Home

When clicking the current link it says:
The page you were looking for doesn't exist

Hence, updating the correct link.