### PR TITLE
Remove CI tests for iOS <= 11. Add CI tests for iOS 15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,8 +127,8 @@ jobs:
     steps:
       - run_tests_flow:
           version_name: "12"
-          os: "12.2"
-          simulator: "iPhone 7"
+          os: "12.4"
+          simulator: "iPhone 8"
 
 
 workflows:


### PR DESCRIPTION
### Purpose
- CircleCI is no longer support testing for iOS 11 and below out of the box.
- New iOS version 15 need to have CI tests.

### Overview
- Remove CI tests for iOS version from and below 11.
- Add CI tests for iOS version 15

### Impact
None

### Rollback
Revert