### PR TITLE
add ios15 as supported os

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Treasure Data iOS SDK
 ===============
 
-iOS and tvOS SDK for [Treasure Data](http://www.treasuredata.com/). With this SDK, you can import the events on your applications into Treasure Data easily. Technically, this library supports iOS 7 and later, but we only execute OS coverage tests for iOS 8, 9, 10, 11, 12, 13 and 14. This SDK also support Apple tvOS 12 and up.
+iOS and tvOS SDK for [Treasure Data](http://www.treasuredata.com/). With this SDK, you can import the events on your applications into Treasure Data easily. Technically, this library supports iOS 7 and later, but we only execute OS coverage tests for iOS 8, 9, 10, 11, 12, 13 ,14 and 15. This SDK also support Apple tvOS 12 and up.
 
 Also, there is an alternative SDK written in Swift [https://github.com/recruit-lifestyle/TreasureDataSDK](https://github.com/recruit-lifestyle/TreasureDataSDK). Note, however, that it does not support current GDPR functionality in the mainstream TD SDKs.
 


### PR DESCRIPTION
As long as I checked, we already have a test for iOS15 and we support the OS, but it is not indicated in README.
So I would like to add it.
https://github.com/treasure-data/td-ios-sdk/blob/22f8b9fee96a9442826e9cbcf526db776e36f76a/.circleci/config.yml#L103

circle CI test result
https://app.circleci.com/pipelines/github/treasure-data/td-ios-sdk/364/workflows/e15005a4-db8c-4dc2-b2d6-44f0402d3a0a/jobs/1507