### PR TITLE
Release 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## version 1.0.1
+_2023-06-05_
+
+* Update KeenClient-iOS to support max number of event to upload per request. Default to 400 events per request.
+
 ## version 1.0.0
 _2023-02-27_
 

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
             targets: ["TreasureData_iOS_SDK"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/treasure-data/KeenClient-iOS.git", .exact("4.0.0")),
+        .package(url: "https://github.com/treasure-data/KeenClient-iOS.git", .exact("4.1.0")),
         .package(url: "https://github.com/nicklockwood/GZIP.git", .upToNextMajor(from: "1.3.0"))
     ],
     targets: [

--- a/Podfile
+++ b/Podfile
@@ -2,7 +2,7 @@ platform :ios, '12.0'
 use_frameworks!
 
 target 'TreasureData' do
-  pod 'KeenClientTD', '= 4.0.0'
+  pod 'KeenClientTD', '= 4.1.0'
   pod 'GZIP', '= 1.3.0'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,12 +1,12 @@
 PODS:
   - GZIP (1.3.0)
-  - KeenClientTD (4.0.0):
-    - KeenClientTD/keen_sqlite (= 4.0.0)
-  - KeenClientTD/keen_sqlite (4.0.0)
+  - KeenClientTD (4.1.0):
+    - KeenClientTD/keen_sqlite (= 4.1.0)
+  - KeenClientTD/keen_sqlite (4.1.0)
 
 DEPENDENCIES:
   - GZIP (= 1.3.0)
-  - KeenClientTD (= 4.0.0)
+  - KeenClientTD (= 4.1.0)
 
 SPEC REPOS:
   https://cdn.cocoapods.org/:
@@ -15,8 +15,8 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   GZIP: 416858efbe66b41b206895ac6dfd5493200d95b3
-  KeenClientTD: 5a1c60b2a4393680a1deeec30f7e461f7398f2c6
+  KeenClientTD: 29a0bee0f807574996e24e88cadd9d9fecdf368c
 
-PODFILE CHECKSUM: 6e7065dea999cebc611545b16f8397d8b061b0be
+PODFILE CHECKSUM: 31704ed47849b202870e9f706c96db3b865a3f15
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.12.1

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ $ gem install cocoapods
 Next, add this line in your Podfile.
 
 ```
-pod 'TreasureData-iOS-SDK', '= 1.0.0'
+pod 'TreasureData-iOS-SDK', '= 1.0.1'
 ```
 
 Add this line to your Podfile (usually at the beginning of the file).
@@ -50,7 +50,7 @@ You can install either via Xcode: File > Swift Packages > Add Package Dependency
 
 Or add this line to `dependencies` array in Package.swift file:
 ```
-.package(url: "https://github.com/treasure-data/td-ios-sdk.git", .upToNextMajor(from: "1.0.0"))
+.package(url: "https://github.com/treasure-data/td-ios-sdk.git", .upToNextMajor(from: "1.0.1"))
 ```
 
 ### Framework

--- a/TreasureData-iOS-SDK.podspec
+++ b/TreasureData-iOS-SDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "TreasureData-iOS-SDK"
-  s.version      = "1.0.0"
+  s.version      = "1.0.1"
   s.summary      = "TreasureData SDK for iOS."
   s.license      = "Apache"
   s.authors      = { "mitsu" => "mitsu@treasure-data.com",

--- a/TreasureData-iOS-SDK.podspec
+++ b/TreasureData-iOS-SDK.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.library      = 'z'
   s.frameworks   = 'Security', 'StoreKit'
   s.public_header_files = ["TreasureData/TreasureData.h", "TreasureData/TDClient.h", "TreasureData/TDRequestOptionsKey.h"]
-  s.dependency "KeenClientTD", '= 4.0.0'
+  s.dependency "KeenClientTD", '= 4.1.0'
   s.dependency "GZIP", '= 1.3.0'
   s.requires_arc = true
 end

--- a/TreasureData/TDClient.m
+++ b/TreasureData/TDClient.m
@@ -13,7 +13,7 @@
 #import "TDClient.h"
 @import GZIP;
 
-static NSString *version = @"1.0.0";
+static NSString *version = @"1.0.1";
 
 @implementation TDClient
 

--- a/TreasureDataExample/Podfile
+++ b/TreasureDataExample/Podfile
@@ -3,11 +3,9 @@ use_frameworks!
 target 'TreasureDataExample' do
   platform :ios, '12.0'
   pod 'TreasureData-iOS-SDK', :path => '..'
-  pod 'KeenClientTD', :path => '../../KeenClient-iOS'
 end
 
 target 'TreasureDataTVOSExample' do
   platform :tvos, '12.0'
   pod 'TreasureData-iOS-SDK', :path => '..'
-  pod 'KeenClientTD', :path => '../../KeenClient-iOS'
 end


### PR DESCRIPTION
* Update KeenClient-iOS to support max number of event to upload per request. Default to 400 events per request.