### PR TITLE
Add NSPrivacyAccessedAPIType

### DIFF
--- a/PrivacyInfo.xcprivacy
+++ b/PrivacyInfo.xcprivacy
@@ -94,5 +94,16 @@
 			</array>
 		</dict>
 	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+	 <dict>
+		<key>NSPrivacyAccessedAPIType</key>
+		<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+		<key>NSPrivacyAccessedAPITypeReasons</key>
+		<array>
+		 <string>CA92.1</string>
+		</array>
+	 </dict>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
td-ios-sdk is using NSUserDefaults to store configurations and ids if needed. So we need to add NSPrivacyAccessedAPIType dict with NSPrivacyAccessedAPICategoryUserDefaults to PrivacyInfo.xcprivacy