### PR TITLE
Add enableAutoTrackingIP & disableAutoTrackingIP

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ jobs:
   test_ios17:
     macos:
       xcode: "15.4.0"
-      resource_class: macos.m1.medium.gen1
+      resource_class: macos.m1.large.gen1
     steps:
       - run_tests_flow:
           os: "17.5"
@@ -155,8 +155,8 @@ workflows:
   test:
     jobs:
       - test_ios17
-      - test_ios16
-      - test_ios15
-      - test_ios14
+      # - test_ios16
+      # - test_ios15
+      # - test_ios14
       - build_spm_ios15
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,16 +108,16 @@ commands:
 jobs:
   test_ios17:
     macos:
-      xcode: "15.1.0"
-      resource_class: macos.m1.large.gen1
+      xcode: "15.4.0"
+      resource_class: macos.m1.medium.gen1
     steps:
       - run_tests_flow:
-          os: "17.2"
+          os: "17.5"
           simulator: "iPhone 15"
 
   test_ios16:
     macos:
-      xcode: "14.3.1"
+      xcode: "15.4.0"
       resource_class: macos.m1.medium.gen1
     steps:
       - run_tests_flow:
@@ -126,7 +126,8 @@ jobs:
 
   test_ios15:
     macos:
-      xcode: "14.1.0"
+      xcode: "14.3.1"
+      resource_class: macos.m1.medium.gen1
     steps:
       - run_tests_flow:
           os: "15.5"
@@ -135,18 +136,11 @@ jobs:
   test_ios14:
     macos:
       xcode: "13.4.1"
+      resource_class: macos.m1.medium.gen1
     steps:
       - run_tests_flow:
           os: "14.5"
           simulator: "iPhone 12"
-
-  test_ios13:
-    macos:
-      xcode: "12.5.1"
-    steps:
-      - run_tests_flow:
-          os: "13.7"
-          simulator: "iPhone 11"
 
   build_spm_ios15:
     macos:
@@ -164,6 +158,5 @@ workflows:
       - test_ios16
       - test_ios15
       - test_ios14
-      - test_ios13
       - build_spm_ios15
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ jobs:
   test_ios17:
     macos:
       xcode: "15.4.0"
-      resource_class: macos.m1.large.gen1
+      resource_class: macos.m1.medium.gen1
     steps:
       - run_tests_flow:
           os: "17.5"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,8 +155,8 @@ workflows:
   test:
     jobs:
       - test_ios17
-      # - test_ios16
-      # - test_ios15
-      # - test_ios14
+      - test_ios16
+      - test_ios15
+      - test_ios14
       - build_spm_ios15
 

--- a/TreasureData.xcodeproj/xcshareddata/xcschemes/TreasureData.xcscheme
+++ b/TreasureData.xcodeproj/xcshareddata/xcschemes/TreasureData.xcscheme
@@ -70,8 +70,7 @@
       </EnvironmentVariables>
       <Testables>
          <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "6B73809D192A09160097D56E"

--- a/TreasureData.xcodeproj/xcshareddata/xcschemes/TreasureData.xcscheme
+++ b/TreasureData.xcodeproj/xcshareddata/xcschemes/TreasureData.xcscheme
@@ -70,7 +70,8 @@
       </EnvironmentVariables>
       <Testables>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "6B73809D192A09160097D56E"

--- a/TreasureData/TDClient.h
+++ b/TreasureData/TDClient.h
@@ -24,6 +24,13 @@
  */
 @property(nonatomic, strong) NSString *apiEndpoint;
 
+#pragma mark - Tracking
+
+/**
+ * Enable tracking td_ip
+ */
+@property BOOL enableTrackingIP;
+
 #pragma mark - Retry
 
 /**

--- a/TreasureData/TDClient.m
+++ b/TreasureData/TDClient.m
@@ -45,6 +45,7 @@ static NSString *version = @"1.1.1";
     self.uploadRetryIntervalBase = 2;
     self.uploadRetryCount = 5;
     self.enableRetryUploading = true;
+    self.enableTrackingIP = false;
     _session = [NSURLSession sharedSession];
     return self;
 }
@@ -72,8 +73,9 @@ static NSString *version = @"1.1.1";
     [request setHTTPMethod:@"POST"];
     [request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
     [request setValue:[NSString stringWithFormat: @"TD1 %@", self.apiKey] forHTTPHeaderField:@"Authorization"];
-    [request setValue:@"application/vnd.treasuredata.v1+json" forHTTPHeaderField:@"Content-Type"];
-    [request setValue:@"application/vnd.treasuredata.v1+json" forHTTPHeaderField:@"Accept"];
+    NSString *contentType = self.enableTrackingIP ? @"application/vnd.treasuredata.v1.mobile+json" : @"application/vnd.treasuredata.v1+json";
+    [request setValue:contentType forHTTPHeaderField:@"Content-Type"];
+    [request setValue:contentType forHTTPHeaderField:@"Accept"];
     [request setValue:[NSString stringWithFormat:@"TD-iOS-SDK/%@ (%@ %@)", version, [[UIDevice currentDevice] systemName], [[UIDevice currentDevice] systemVersion]] forHTTPHeaderField:@"User-Agent"];
     
     if (_enableEventCompression) {

--- a/TreasureData/TreasureData.h
+++ b/TreasureData/TreasureData.h
@@ -318,6 +318,16 @@ typedef void (^ErrorHandler)(NSString* _Nonnull errorCode, NSString* _Nullable e
  */
 - (void)disableAutoAppendAdvertisingIdentifier;
 
+/**
+ * Automatically tracking device's IP address in `td_ip` column. Disabled by default
+ */
+- (void)enableAutoTrackingIP;
+
+/**
+ * Disable automatically tracking device's IP
+ */
+- (void)disableAutoTrackingIP;
+
 #pragma mark - Session
 
 /**

--- a/TreasureData/TreasureData.m
+++ b/TreasureData/TreasureData.m
@@ -615,6 +615,14 @@ static NSString *TreasureDataErrorDomain = @"com.treasuredata";
     self.autoAppendAdvertisingIdColumn = nil;
 }
 
+- (void)enableAutoTrackingIP {
+    self.client.enableTrackingIP = true;
+}
+
+- (void)disableAutoTrackingIP {
+    self.client.enableTrackingIP = false;
+}
+
 + (instancetype)sharedInstance {
     NSAssert(sharedInstance, @"%@ sharedInstance is called before [TreasureData initializeWithApiKey:]", self);
     return sharedInstance;

--- a/TreasureDataTests/IntegrationTests.swift
+++ b/TreasureDataTests/IntegrationTests.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+import Network
 
 class IntegrationTests: XCTestCase {
 
@@ -172,6 +173,26 @@ class IntegrationTests: XCTestCase {
         XCTAssert(result[0][0] as! String != result[1][0] as! String)
     }
     
+    func testEnableTrackingIP() {
+        let table = newTempTable()
+        sdkClient.enableCustomEvent()
+        sdkClient.enableAutoTrackingIP()
+        sdkClient.addEvent([:], table: table)
+        sdkClient.uploadEvents()
+        let result = try! IntegrationTests.api.stubbornQuery("select td_ip from \(table) limit 1", database: IntegrationTests.TargetDatabase)
+        XCTAssert(IntegrationTests.isValidIPAddress(address: result[0][0] as? String))
+    }
+    
+    func testDisableTrackingIP() {
+        let table = newTempTable()
+        sdkClient.enableAutoTrackingIP()
+        sdkClient.addEvent([:], table: table)
+        sdkClient.disableAutoTrackingIP() // Will disable auto tracking td_ip in all events
+        sdkClient.uploadEvents()
+        let result = try! IntegrationTests.api.stubbornQuery("select td_ip from \(table) limit 1", database: IntegrationTests.TargetDatabase)
+        XCTAssert(!IntegrationTests.isValidIPAddress(address: result[0][0] as? String))
+    }
+
     func testFetchUserSegmentsSucceed() {
         let expectation = self.expectation(description: "fetchUserSegments should succeed")
         sdkClient.fetchUserSegments(tokens: IntegrationTests.audienceTokens, keys: IntegrationTests.userSegmentKeys) { (jsonResponse, error) in
@@ -200,5 +221,10 @@ class IntegrationTests: XCTestCase {
 
     static func uuid() -> String {
         return NSUUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "_")
+    }
+    
+    static func isValidIPAddress(address: String?) -> Bool {
+        guard let address = address else { return false }
+        return IPv4Address(address) != nil || IPv6Address(address) != nil
     }
 }

--- a/TreasureDataTests/IntegrationTests.swift
+++ b/TreasureDataTests/IntegrationTests.swift
@@ -187,10 +187,11 @@ class IntegrationTests: XCTestCase {
         let table = newTempTable()
         sdkClient.enableAutoTrackingIP()
         sdkClient.addEvent([:], table: table)
-        sdkClient.disableAutoTrackingIP() // Will disable auto tracking td_ip in all events
+        sdkClient.disableAutoTrackingIP() // Will disable auto tracking td_ip in both 2 added events
+        sdkClient.addEvent([:], table: table)
         sdkClient.uploadEvents()
-        let result = try! IntegrationTests.api.stubbornQuery("select td_ip from \(table) limit 1", database: IntegrationTests.TargetDatabase)
-        XCTAssert(!IntegrationTests.isValidIPAddress(address: result[0][0] as? String))
+        let result = try! IntegrationTests.api.stubbornQuery("select * from \(table) limit 2", database: IntegrationTests.TargetDatabase)
+        XCTAssert(result[0].count == 1 && result[1].count == 1) // count == 0 means only 1 column 'time', so there is no td_ip column
     }
 
     func testFetchUserSegmentsSucceed() {

--- a/TreasureDataTests/IntegrationTests.swift
+++ b/TreasureDataTests/IntegrationTests.swift
@@ -191,7 +191,7 @@ class IntegrationTests: XCTestCase {
         sdkClient.addEvent([:], table: table)
         sdkClient.uploadEvents()
         let result = try! IntegrationTests.api.stubbornQuery("select * from \(table) limit 2", database: IntegrationTests.TargetDatabase)
-        XCTAssert(result[0].count == 1 && result[1].count == 1) // count == 0 means only 1 column 'time', so there is no td_ip column
+        XCTAssert(result[0].count == 1 && result[1].count == 1) // count == 1 means only 1 column 'time', so there is no td_ip column
     }
 
     func testFetchUserSegmentsSucceed() {

--- a/TreasureDataTests/TDAPI.swift
+++ b/TreasureDataTests/TDAPI.swift
@@ -73,7 +73,7 @@ class TDAPI {
      *
      * - Parameter timeout: timeout in seconds, default is 30 minutes
      */
-    func stubbornQuery(_ query: String, database: String, timeout: TimeInterval = 30 * 60) throws -> [[Any]] {
+    func stubbornQuery(_ query: String, database: String, timeout: TimeInterval = 15 * 60) throws -> [[Any]] {
         let started = Date()
 
         func doRetry(_ query: String, database: String) throws -> [[Any]] {

--- a/TreasureDataTests/TreasureDataTests.m
+++ b/TreasureDataTests/TreasureDataTests.m
@@ -1027,6 +1027,29 @@ static NSString *END_POINT = @"http://localhost";
     }
 }
 
+#pragma mark - Tracking td_ip
+
+- (void)testTrackingIPEnabled {
+    @try {
+        XCTAssertFalse(self.td.client.enableTrackingIP);
+        [self.td enableAutoTrackingIP];
+        XCTAssertTrue(self.td.client.enableTrackingIP);
+    } @finally {
+        self.isFinished = YES;
+    }
+}
+
+- (void)testTrackingIPDisabled {
+    @try {
+        [self.td enableAutoTrackingIP];
+        XCTAssertTrue(self.td.client.enableTrackingIP);
+        [self.td disableAutoTrackingIP];
+        XCTAssertFalse(self.td.client.enableTrackingIP);
+    } @finally {
+        self.isFinished = YES;
+    }
+}
+
 #pragma mark - Default Values
 
 - (void) testAddDefaultValuesSuccesfully {


### PR DESCRIPTION
New feature:
- `enableAutoTrackingIP` will tell TD backend to add `td_ip` column with the device ip
- `disableAutoTrackingIP` will disable this behavior.

Note: IP is tracked at the request level. Which means the IP address is the one when `uploadEvents` is called.