### PR TITLE
CI tests for iOS 18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,6 +106,15 @@ commands:
       - store_results
 
 jobs:
+  test_ios18:
+    macos:
+      xcode: "16.1.0"
+      resource_class: macos.m1.medium.gen1
+    steps:
+      - run_tests_flow:
+          os: "18.1"
+          simulator: "iPhone 16"
+
   test_ios17:
     macos:
       xcode: "15.4.0"
@@ -154,6 +163,7 @@ workflows:
   version: 2
   test:
     jobs:
+      - test_ios18
       - test_ios17
       - test_ios16
       - test_ios15

--- a/README.md
+++ b/README.md
@@ -568,6 +568,7 @@ This SDK supports Apple tvOS version 12 and up. APIs and their behaviors are lar
 
 | iOS Version | v0.8.0             | v0.9.0             | v1.0.1             | v1.1.0             | v1.1.1             | v1.2.0             |
 | :---------- | :----------------- | :----------------- | :----------------- | :----------------- | :----------------- | :----------------- |
+| 18          | not tested         | not tested         | not tested         | not tested         | not tested         | :white_check_mark: |
 | 17          | not tested         | not tested         | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | 16          | not tested         | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | 15          | not tested         | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |


### PR DESCRIPTION
- Add CI tests for iOS 18
- Update README supporting iOS 18 for version 1.2.0