### PR TITLE
iOS 26 Support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,7 +127,7 @@ jobs:
       resource_class: m4pro.medium
     steps:
       - run_tests_flow:
-          os: "18.2"
+          os: "18.5"
           simulator: "iPhone 16"
 
   test_ios17:
@@ -160,7 +160,7 @@ jobs:
   test_ios14:
     macos:
       xcode: "13.4.1"
-      resource_class: m4pro.medium
+      resource_class: m2pro.medium
     steps:
       - run_tests_flow:
           os: "14.5"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,6 +112,15 @@ commands:
       - store_results
 
 jobs:
+  test_ios26:
+    macos:
+      xcode: "26.1.0"
+      resource_class: m2pro.medium
+    steps:
+      - run_tests_flow:
+          os: "26.1"
+          simulator: "iPhone 17"
+
   test_ios18:
     macos:
       xcode: "16.2.0"
@@ -169,6 +178,7 @@ workflows:
   version: 2
   test:
     jobs:
+      - test_ios26
       - test_ios18
       - test_ios17
       - test_ios16

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,7 @@ jobs:
   test_ios26:
     macos:
       xcode: "26.1.0"
-      resource_class: m2pro.medium
+      resource_class: m4pro.medium
     steps:
       - run_tests_flow:
           os: "26.1"
@@ -123,8 +123,8 @@ jobs:
 
   test_ios18:
     macos:
-      xcode: "16.2.0"
-      resource_class: m2pro.medium
+      xcode: "16.4.0"
+      resource_class: m4pro.medium
     steps:
       - run_tests_flow:
           os: "18.2"
@@ -133,7 +133,7 @@ jobs:
   test_ios17:
     macos:
       xcode: "15.4.0"
-      resource_class: macos.m1.medium.gen1
+      resource_class: m4pro.medium
     steps:
       - run_tests_flow:
           os: "17.5"
@@ -142,7 +142,7 @@ jobs:
   test_ios16:
     macos:
       xcode: "15.4.0"
-      resource_class: macos.m1.medium.gen1
+      resource_class: m4pro.medium
     steps:
       - run_tests_flow:
           os: "16.4"
@@ -151,7 +151,7 @@ jobs:
   test_ios15:
     macos:
       xcode: "14.3.1"
-      resource_class: macos.m1.medium.gen1
+      resource_class: m4pro.medium
     steps:
       - run_tests_flow:
           os: "15.5"
@@ -160,7 +160,7 @@ jobs:
   test_ios14:
     macos:
       xcode: "13.4.1"
-      resource_class: macos.m1.medium.gen1
+      resource_class: m4pro.medium
     steps:
       - run_tests_flow:
           os: "14.5"

--- a/README.md
+++ b/README.md
@@ -568,6 +568,7 @@ This SDK supports Apple tvOS version 12 and up. APIs and their behaviors are lar
 
 | iOS Version | v0.8.0             | v0.9.0             | v1.0.1             | v1.1.0             | v1.1.1             | v1.2.0 & v1.2.1    |
 | :---------- | :----------------- | :----------------- | :----------------- | :----------------- | :----------------- | :----------------- |
+| 26          | not tested         | not tested         | not tested         | not tested         | not tested         | :white_check_mark: |
 | 18          | not tested         | not tested         | not tested         | not tested         | not tested         | :white_check_mark: |
 | 17          | not tested         | not tested         | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | 16          | not tested         | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |


### PR DESCRIPTION
- Add CI test for iOS 26
- Update resource_class for test jobs.
- Update README to include iOS 26 support