### PR TITLE
Deprecate Tracking IAP

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,18 +157,9 @@ jobs:
           os: "15.5"
           simulator: "iPhone 13"
 
-  test_ios14:
-    macos:
-      xcode: "13.4.1"
-      resource_class: m2pro.medium
-    steps:
-      - run_tests_flow:
-          os: "14.5"
-          simulator: "iPhone 12"
-
   build_spm_ios15:
     macos:
-      xcode: "13.4.1"
+      xcode: "14.3.1"
     steps:
       - build_spm:
           os: "15.5"
@@ -183,6 +174,5 @@ workflows:
       - test_ios17
       - test_ios16
       - test_ios15
-      - test_ios14
       - build_spm_ios15
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -9,7 +9,7 @@ DEPENDENCIES:
   - KeenClientTD (= 4.1.1)
 
 SPEC REPOS:
-  https://cdn.cocoapods.org/:
+  trunk:
     - GZIP
     - KeenClientTD
 
@@ -19,4 +19,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: c7c56130903936173a7ecee314611a525c115504
 
-COCOAPODS: 1.16.1
+COCOAPODS: 1.16.2

--- a/README.md
+++ b/README.md
@@ -486,6 +486,9 @@ Example of a tracked install event:
 
 #### In-App Purchase Events
 
+> [!NOTE]
+> This feature is deprecate as original API for In-App Purchase, a.k.a Store Kit 1 is no longer supported by Apple. It's recommended to directly track your In App Purchase in your app code by using `-[TreasureData addEvent:database:table]` instead.
+
 TreasureData SDK is able to automatically track IAP `SKPaymentTransactionStatePurchased` event without having to write your own transaction observer.
 
 

--- a/README.md
+++ b/README.md
@@ -487,7 +487,7 @@ Example of a tracked install event:
 #### In-App Purchase Events
 
 > [!NOTE]
-> This feature is deprecate as original API for In-App Purchase, a.k.a Store Kit 1 is no longer supported by Apple. It's recommended to directly track your In App Purchase in your app code by using `-[TreasureData addEvent:database:table]` instead.
+> This feature is deprecated as original API for In-App Purchase, a.k.a Store Kit 1, is no longer supported by Apple. It's recommended to directly track In-App Purchase in your app code by using `-[TreasureData addEvent:database:table]` instead.
 
 TreasureData SDK is able to automatically track IAP `SKPaymentTransactionStatePurchased` event without having to write your own transaction observer.
 

--- a/TreasureData/TreasureData.h
+++ b/TreasureData/TreasureData.h
@@ -433,6 +433,7 @@ typedef void (^ErrorHandler)(NSString* _Nonnull errorCode, NSString* _Nullable e
 
 /**
  * Enable tracking `SKPaymentTransactionStatePurchased` event automatically. This is disabled by default. Unlike custom and app lifecycle events, this settings is not persisted.
+ * @deprecated This method is deprecated because it uses StoreKit 1 under the hood. Directly track In App Purchase in your app code instead.
  *
  * An example IAP event record:
  * ```
@@ -446,12 +447,13 @@ typedef void (^ErrorHandler)(NSString* _Nonnull errorCode, NSString* _Nullable e
  * "td_iap_product_localized_description": "Your Product Description",
  * "td_iap_product_currency_code": "USD",  // this is only available on iOS 10 and above
  */
-- (void)enableInAppPurchaseEvent;
+- (void)enableInAppPurchaseEvent __attribute__((deprecated("This method is deprecated because it uses StoreKit 1 under the hood. Directly track In App Purchase in your app code instead.")));
 
 /**
  * Disable tracking IAP events
+ * @deprecated This method is deprecated as part of `enableInAppPurchaseEvent` deprecation. Directly track In App Purchase in your app code instead.
  */
-- (void)disableInAppPurchaseEvent;
+- (void)disableInAppPurchaseEvent __attribute__((deprecated("This method is deprecated as part of `enableInAppPurchaseEvent` deprecation. Directly track In App Purchase in your app code instead.")));
 
 /**
  * Whether this `TreasureData`'s instance tracking IAP events

--- a/TreasureDataInternal/TDIAPObserver.m
+++ b/TreasureDataInternal/TDIAPObserver.m
@@ -196,8 +196,10 @@
 - (void)productsRequest:(nonnull SKProductsRequest *)request didReceiveResponse:(nonnull SKProductsResponse *)response {
     dispatch_async(_observer.trackIAPQueue, ^{
         @try {
-            SKProduct *product = response.products[0];  // we always request for a single product
-            [self->_observer flushTransactionOfProduct:product];
+            SKProduct *product = response.products.firstObject;  // we always request for a single product
+            if (product != nil) {
+                [self->_observer flushTransactionOfProduct:product];
+            }
             [self stop];
         }
         @catch (NSException *exception) {

--- a/TreasureDataInternal/TDUtils.m
+++ b/TreasureDataInternal/TDUtils.m
@@ -77,12 +77,7 @@
 }
 
 + (BOOL)isStoreKitAvailable {
-    for (NSBundle *bundle in NSBundle.allFrameworks) {
-        if ([bundle classNamed:@"SKStoreProductViewController"]) {
-            return YES;
-        }
-    }
-    return NO;
+    return NSClassFromString(@"SKStoreProductViewController") != nil;
 }
 
 @end


### PR DESCRIPTION
This PR is for:
- Providing performance improvement for isStoreKitAvailable
- Add a guard when accessing first SKProduct
- Deprecate tracking IAP
- Remove CI test for iOS 14